### PR TITLE
Fix router registration in startup

### DIFF
--- a/app/startup.py
+++ b/app/startup.py
@@ -36,15 +36,15 @@ class ApplicationSetup:
     def __init__(self) -> None:
         self.app = FastAPI()
         self._router_configs: List[Tuple[APIRouter, str]] = [
-            (auth.router, "Auth"),
-            (families.router, "Families"),
-            (groups.router, "Groups"),
-            (tasks.router, "Tasks"),
-            (users.router, "Users"),
-            (reports.router, "Reports"),
-            (notifications.router, "Notifications"),
-            (settings.router, "Settings"),
-            (admin.router, "Admin"),
+            (auth, "Auth"),
+            (families, "Families"),
+            (groups, "Groups"),
+            (tasks, "Tasks"),
+            (users, "Users"),
+            (reports, "Reports"),
+            (notifications, "Notifications"),
+            (settings, "Settings"),
+            (admin, "Admin"),
         ]
 
     def setup_cors(self) -> None:


### PR DESCRIPTION
## Summary
- fix `APIRouter` initialisation by using exported router objects directly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859829503d4832a9876c853e6f5b8d5