### PR TITLE
Fix family relationship join and add initial migration

### DIFF
--- a/alembic/versions/94e68349488e_initial_migration.py
+++ b/alembic/versions/94e68349488e_initial_migration.py
@@ -1,0 +1,92 @@
+"""Initial migration
+
+Revision ID: 94e68349488e
+Revises: 
+Create Date: 2025-06-22 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = '94e68349488e'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('username', sa.String(), nullable=False, unique=True, index=True),
+        sa.Column('email', sa.String(), nullable=False, unique=True, index=True),
+        sa.Column('hashed_password', sa.String(), nullable=False),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+    )
+
+    op.create_table(
+        'groups',
+        sa.Column('id', sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column('name', sa.String(length=100), nullable=False, unique=True, index=True),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_by', sa.String(length=100), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.Column('user_ids', postgresql.ARRAY(sa.Integer()), nullable=False, server_default=sa.text("'{}'")),
+    )
+
+    op.create_table(
+        'tasks',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('title', sa.String(length=255), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('is_completed', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('priority', sa.Integer(), nullable=False, server_default='1'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('completed_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('assigned_user_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['assigned_user_id'], ['users.id'], ondelete='SET NULL'),
+    )
+
+    op.create_table(
+        'task_groups',
+        sa.Column('task_id', sa.Integer(), nullable=False),
+        sa.Column('group_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['task_id'], ['tasks.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['group_id'], ['groups.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('task_id', 'group_id')
+    )
+
+    op.create_table(
+        'settings',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), nullable=False, unique=True),
+        sa.Column('theme', sa.String(length=50), nullable=False, server_default='light'),
+        sa.Column('notifications_enabled', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    )
+
+    op.create_table(
+        'notifications',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('message', sa.Text(), nullable=False),
+        sa.Column('is_read', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('notifications')
+    op.drop_table('settings')
+    op.drop_table('task_groups')
+    op.drop_table('tasks')
+    op.drop_table('groups')
+    op.drop_table('users')

--- a/alembic/versions/e0f7381c0a9f_add_user_fields.py
+++ b/alembic/versions/e0f7381c0a9f_add_user_fields.py
@@ -13,7 +13,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = 'e0f7381c0a9f'
-down_revision: Union[str, None] = None
+down_revision: Union[str, None] = '94e68349488e'
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -29,7 +29,9 @@ class Family(Base):
     )
 
     members: Mapped[List["User"]] = relationship(
-        "User", back_populates="family"
+        "User",
+        back_populates="family",
+        foreign_keys="User.family_id",
     )
     premium_members: Mapped[List["User"]] = relationship(
         "User",

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -63,7 +63,11 @@ class User(Base):
         cascade="all, delete-orphan",
     )
 
-    family = relationship("Family", back_populates="members")
+    family = relationship(
+        "Family",
+        back_populates="members",
+        foreign_keys="User.family_id",
+    )
     families = relationship(
         "Family",
         secondary=user_family_membership,


### PR DESCRIPTION
## Summary
- provide initial Alembic migration creating the core tables
- link later user migration to the new initial revision
- specify `foreign_keys` on `User.family` and `Family.members` to avoid ambiguous joins

## Testing
- `pytest -q`
- `poetry run alembic upgrade head` *(fails: OperationalError: could not translate host name "postgres_db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6859861015e8832a9c7e60118dc95827