### PR TITLE
Implement admin auth with default admin user

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -9,14 +9,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.models.user import User
-from app.schemas.user import UserAdminResponseSchema
+from app.schemas.user import UserAdminResponseSchema, UserUpdateSchema
+from app.core.security import get_current_superuser
+from app.crud.user import update_user as crud_update_user
 
 
-router = APIRouter(prefix="/admin", tags=["admin"])
+router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    dependencies=[Depends(get_current_superuser)],
+)
 
 
 @router.get("/users", response_model=List[UserAdminResponseSchema])
-async def admin_get_users(db: AsyncSession = Depends(get_database_session)) -> List[UserAdminResponseSchema]:
+async def admin_get_users(
+    db: AsyncSession = Depends(get_database_session),
+) -> List[UserAdminResponseSchema]:
     """Return all users with related data for admin inspection."""
     result = await db.execute(
         select(User)
@@ -33,7 +41,10 @@ async def admin_get_users(db: AsyncSession = Depends(get_database_session)) -> L
 
 
 @router.get("/users/{user_id}", response_model=UserAdminResponseSchema)
-async def admin_get_user(user_id: int, db: AsyncSession = Depends(get_database_session)) -> UserAdminResponseSchema:
+async def admin_get_user(
+    user_id: int,
+    db: AsyncSession = Depends(get_database_session),
+) -> UserAdminResponseSchema:
     """Return a single user with all related data."""
     result = await db.execute(
         select(User)
@@ -47,6 +58,18 @@ async def admin_get_user(user_id: int, db: AsyncSession = Depends(get_database_s
         )
     )
     user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return UserAdminResponseSchema.model_validate(user)
+
+
+@router.post("/users/{user_id}/make-admin", response_model=UserAdminResponseSchema)
+async def make_user_admin(
+    user_id: int,
+    db: AsyncSession = Depends(get_database_session),
+) -> UserAdminResponseSchema:
+    """Grant administrative rights to the specified user."""
+    user = await crud_update_user(db, user_id, UserUpdateSchema(is_superuser=True))
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     return UserAdminResponseSchema.model_validate(user)


### PR DESCRIPTION
## Summary
- secure all admin endpoints with JWT auth
- add endpoint to grant admin privileges to users
- create default `admin` account on startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68598862c568832aa8a34142200a046e