### PR TITLE
Track task assigner and group aggregation

### DIFF
--- a/alembic/versions/5c7f3042b1b1_add_assigned_by_to_tasks.py
+++ b/alembic/versions/5c7f3042b1b1_add_assigned_by_to_tasks.py
@@ -1,0 +1,30 @@
+"""add assigned_by_user_id to tasks
+
+Revision ID: 5c7f3042b1b1
+Revises: e0f7381c0a9f
+Create Date: 2025-07-01 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '5c7f3042b1b1'
+down_revision: Union[str, None] = 'e0f7381c0a9f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('tasks', sa.Column('assigned_by_user_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(
+        'fk_tasks_assigned_by_user_id_users',
+        'tasks', 'users', ['assigned_by_user_id'], ['id'], ondelete='SET NULL'
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_tasks_assigned_by_user_id_users', 'tasks', type_='foreignkey')
+    op.drop_column('tasks', 'assigned_by_user_id')

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -61,6 +61,13 @@ class User(Base):
         back_populates="assigned_user",
         cascade="all, delete-orphan",
     )
+    # Tasks this user assigned to others
+    assigned_tasks = relationship(
+        "Task",
+        back_populates="assigned_by",
+        foreign_keys="Task.assigned_by_user_id",
+        lazy="selectin",
+    )
 
     family = relationship(
         "Family",

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.models.task import Task
-from app.models.associations import task_group_association
+from app.models.associations import task_group_association, user_group_membership
 from app.schemas.task import TaskResponseSchema
 
 router = APIRouter()
@@ -30,10 +30,42 @@ async def get_user_task_report(user_id: int, db: AsyncSession = Depends(get_data
     return [TaskResponseSchema.model_validate(task) for task in tasks]
 
 
+@router.get("/tasks/reports/assigned-by/{user_id}", response_model=List[TaskResponseSchema])
+async def get_tasks_assigned_by_user(
+    user_id: int, db: AsyncSession = Depends(get_database_session)
+):
+    stmt = select(Task).where(
+        Task.assigned_by_user_id == user_id,
+        Task.assigned_user_id.isnot(None),
+        Task.assigned_user_id != user_id,
+    )
+    result = await db.execute(stmt)
+    tasks = result.scalars().all()
+    return [TaskResponseSchema.model_validate(task) for task in tasks]
+
+
 @router.get("/tasks/reports/group/{group_id}", response_model=List[TaskResponseSchema])
 async def get_group_task_report(group_id: int, db: AsyncSession = Depends(get_database_session)):
     result = await db.execute(
         select(Task).join(task_group_association).where(task_group_association.c.group_id == group_id)
     )
     tasks = result.scalars().all()
+    return [TaskResponseSchema.model_validate(task) for task in tasks]
+
+
+@router.get("/tasks/reports/user/{user_id}/groups", response_model=List[TaskResponseSchema])
+async def get_user_groups_tasks(
+    user_id: int, db: AsyncSession = Depends(get_database_session)
+):
+    stmt = (
+        select(Task)
+        .join(task_group_association)
+        .join(
+            user_group_membership,
+            task_group_association.c.group_id == user_group_membership.c.group_id,
+        )
+        .where(user_group_membership.c.user_id == user_id)
+    )
+    result = await db.execute(stmt)
+    tasks = result.scalars().unique().all()
     return [TaskResponseSchema.model_validate(task) for task in tasks]

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -15,6 +15,7 @@ from app.schemas.task import (
     TaskResponseSchema,
     TaskUpdateSchema,
     TaskAssignGroupsSchema,
+    TaskAssignUserSchema,
 )
 
 router = APIRouter(
@@ -156,11 +157,10 @@ async def delete_task(
 async def assign_task_to_user(
         task_id: int,
         user_id: int,
+        assignment: TaskAssignUserSchema,
         db: AsyncSession = Depends(get_database_session)
 ) -> TaskResponseSchema:
-    """
-    Assign a task to a specific user.
-    """
+    """Assign a task to a specific user."""
     query = select(Task).where(Task.id == task_id)
     result = await db.execute(query)
     task = result.scalar_one_or_none()
@@ -172,6 +172,7 @@ async def assign_task_to_user(
         )
 
     task.assigned_user_id = user_id
+    task.assigned_by_user_id = assignment.assigned_by_user_id
     await db.commit()
     await db.refresh(task)
     return TaskResponseSchema.model_validate(task)
@@ -207,6 +208,7 @@ async def unassign_task_from_user(
         )
 
     task.assigned_user_id = None
+    task.assigned_by_user_id = None
     await db.commit()
     await db.refresh(task)
     return TaskResponseSchema.model_validate(task)

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -24,7 +24,12 @@ class TaskBaseSchema(BaseModel):
 
 class TaskCreateSchema(TaskBaseSchema):
     """Schema for creating a new task."""
-    pass
+    assigned_user_id: Optional[int] = Field(
+        ..., gt=0, description="ID of the user to assign; null for unassigned"
+    )
+    assigned_by_user_id: int = Field(
+        ..., gt=0, description="ID of the user who assigns the task"
+    )
 
 
 class TaskUpdateSchema(BaseModel):
@@ -34,6 +39,7 @@ class TaskUpdateSchema(BaseModel):
     priority: Optional[int] = Field(None, ge=1, le=5)
     is_completed: Optional[bool] = None
     assigned_user_id: Optional[int] = Field(None, gt=0)
+    assigned_by_user_id: Optional[int] = Field(None, gt=0)
 
     class Config:
         from_attributes = True
@@ -54,10 +60,22 @@ class TaskResponseSchema(TaskBaseSchema):
         gt=0,
         description="ID of the user assigned to this task"
     )
+    assigned_by_user_id: Optional[int] = Field(
+        None,
+        gt=0,
+        description="ID of the user who assigned this task",
+    )
 
 class TaskAssignGroupsSchema(BaseModel):
     """Schema for assigning task to groups."""
     group_ids: Annotated[List[int], Field(min_length=1)]
+
+    model_config = ConfigDict(frozen=True)
+
+
+class TaskAssignUserSchema(BaseModel):
+    """Schema for assigning a task to a user."""
+    assigned_by_user_id: int = Field(gt=0)
 
     model_config = ConfigDict(frozen=True)
 


### PR DESCRIPTION
## Summary
- require assignee information when creating tasks and track who assigns them
- allow reassigning tasks with recorded assigning user
- expose reports for tasks assigned by a user and tasks from all groups a user belongs to

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68985987c0b0832a80ec2805b41cda37