### PR TITLE
Add task reward points and user award logic

### DIFF
--- a/alembic/versions/a2a8cfb93f7b_add_reward_points_to_tasks.py
+++ b/alembic/versions/a2a8cfb93f7b_add_reward_points_to_tasks.py
@@ -1,0 +1,30 @@
+"""add reward_points_to_tasks
+
+Revision ID: a2a8cfb93f7b
+Revises: 5c7f3042b1b1
+Create Date: 2025-08-10 09:32:26.269276
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a2a8cfb93f7b'
+down_revision: Union[str, None] = '5c7f3042b1b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'tasks',
+        sa.Column('reward_points', sa.Integer(), nullable=False, server_default=sa.text('0'))
+    )
+    op.alter_column('tasks', 'reward_points', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('tasks', 'reward_points')

--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.task import Task
 from app.models.group import Group
+from app.models.user import User
 from app.schemas.task import TaskCreateSchema, TaskResponseSchema, TaskUpdateSchema
 
 UTC = ZoneInfo("UTC")
@@ -49,6 +50,7 @@ class TaskRepository:
         db_task = Task(
             title=task_data.title,
             description=task_data.description,
+            reward_points=task_data.reward_points,
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC)
         )
@@ -108,12 +110,24 @@ class TaskRepository:
 
         update_data = task_data.model_dump(exclude_unset=True)
 
+        was_completed = task.is_completed
+
         for key, value in update_data.items():
             setattr(task, key, value)
 
         task.updated_at = datetime.now(UTC)
-        if update_data.get('is_completed'):
-            task.completed_at = datetime.now(UTC)
+        if update_data.get('is_completed') is not None:
+            if update_data['is_completed']:
+                task.completed_at = datetime.now(UTC)
+                if not was_completed and task.assigned_user_id is not None:
+                    user_result = await self.db.execute(
+                        select(User).where(User.id == task.assigned_user_id)
+                    )
+                    user = user_result.scalars().first()
+                    if user:
+                        user.points += task.reward_points
+            else:
+                task.completed_at = None
 
         await self.db.commit()
         await self.db.refresh(task)

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -22,6 +22,7 @@ class Task(Base):
     description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     is_completed: Mapped[bool] = mapped_column(Boolean, default=False)
     priority: Mapped[int] = mapped_column(Integer, default=1)
+    reward_points: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -17,6 +17,11 @@ class TaskBaseSchema(BaseModel):
         le=5,
         description="Task priority from 1 to 5"
     )
+    reward_points: int = Field(
+        default=0,
+        ge=0,
+        description="Reward points for completing the task"
+    )
 
     class Config:
         from_attributes = True
@@ -40,6 +45,7 @@ class TaskUpdateSchema(BaseModel):
     is_completed: Optional[bool] = None
     assigned_user_id: Optional[int] = Field(None, gt=0)
     assigned_by_user_id: Optional[int] = Field(None, gt=0)
+    reward_points: Optional[int] = Field(None, ge=0)
 
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add `reward_points` field to task model and schemas
- award points to users when tasks are marked completed
- provide migration for new `reward_points` column

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689866657a1c832a84cec2fd788e6b4b