### PR TITLE
feat: add soft delete to tasks

### DIFF
--- a/alembic/versions/94eedaa9c884_add_deleted_at_to_tasks.py
+++ b/alembic/versions/94eedaa9c884_add_deleted_at_to_tasks.py
@@ -1,0 +1,34 @@
+"""add deleted_at to tasks
+
+Revision ID: 94eedaa9c884
+Revises: 5c7f3042b1b1
+Create Date: 2025-08-10 09:31:25.600708
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '94eedaa9c884'
+down_revision: Union[str, None] = '5c7f3042b1b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'tasks',
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True)
+    )
+    op.add_column(
+        'tasks',
+        sa.Column('is_archived', sa.Boolean(), nullable=False, server_default='false')
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('tasks', 'is_archived')
+    op.drop_column('tasks', 'deleted_at')

--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import select, delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.task import Task
@@ -67,7 +67,9 @@ class TaskRepository:
         Returns:
             Task details if found, None otherwise
         """
-        query = select(Task).where(Task.id == task_id)
+        query = select(Task).where(
+            Task.id == task_id, Task.deleted_at.is_(None)
+        )
         result = await self.db.execute(query)
         task = result.scalars().first()
         if task is None:
@@ -81,7 +83,7 @@ class TaskRepository:
         Returns:
             List of task details
         """
-        query = select(Task)
+        query = select(Task).where(Task.deleted_at.is_(None))
         result = await self.db.execute(query)
         tasks = list(result.scalars().all())
         return [self._to_task_details(task) for task in tasks]
@@ -100,7 +102,9 @@ class TaskRepository:
         Raises:
             TaskNotFoundError: If task with given ID doesn't exist
         """
-        result = await self.db.execute(select(Task).where(Task.id == task_id))
+        result = await self.db.execute(
+            select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
+        )
         task = result.scalars().first()
 
         if not task:
@@ -129,10 +133,28 @@ class TaskRepository:
         Returns:
             True if task was deleted, False if task wasn't found
         """
-        query = delete(Task).where(Task.id == task_id)
-        result = await self.db.execute(query)
+        result = await self.db.execute(
+            select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
+        )
+        task = result.scalars().first()
+        if not task:
+            return False
+        task.deleted_at = datetime.now(UTC)
+        task.is_archived = True
         await self.db.commit()
-        return bool(result.rowcount)
+        return True
+
+    async def restore(self, task_id: int) -> TaskResponseSchema:
+        """Restore an archived task by ID."""
+        result = await self.db.execute(select(Task).where(Task.id == task_id))
+        task = result.scalars().first()
+        if not task or task.deleted_at is None:
+            raise TaskNotFoundError(f"Task with id {task_id} not found or not archived")
+        task.deleted_at = None
+        task.is_archived = False
+        await self.db.commit()
+        await self.db.refresh(task)
+        return self._to_task_details(task)
 
     async def assign_to_user(self, task_id: int, user_id: int) -> TaskResponseSchema:
         """
@@ -165,7 +187,9 @@ class TaskRepository:
         Raises:
             TaskNotFoundError: If a task with a given ID doesn't exist
         """
-        result = await self.db.execute(select(Task).where(Task.id == task_id))
+        result = await self.db.execute(
+            select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
+        )
         task = result.scalars().first()
 
         if not task:

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -35,6 +35,11 @@ class Task(Base):
         DateTime(timezone=True),
         nullable=True,
     )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    is_archived: Mapped[bool] = mapped_column(Boolean, default=False)
 
     assigned_user_id: Mapped[Optional[int]] = mapped_column(
         Integer,

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -14,10 +14,14 @@ router = APIRouter()
 
 @router.get("/tasks/reports/summary")
 async def get_task_summary(db: AsyncSession = Depends(get_database_session)):
-    total_result = await db.execute(select(func.count()).select_from(Task))
+    total_result = await db.execute(
+        select(func.count()).select_from(Task).where(Task.deleted_at.is_(None))
+    )
     total = total_result.scalar_one()
     completed_result = await db.execute(
-        select(func.count()).select_from(Task).where(Task.is_completed.is_(True))
+        select(func.count())
+        .select_from(Task)
+        .where(Task.is_completed.is_(True), Task.deleted_at.is_(None))
     )
     completed = completed_result.scalar_one()
     return {"total_tasks": total, "completed_tasks": completed}
@@ -25,7 +29,11 @@ async def get_task_summary(db: AsyncSession = Depends(get_database_session)):
 
 @router.get("/tasks/reports/user/{user_id}", response_model=List[TaskResponseSchema])
 async def get_user_task_report(user_id: int, db: AsyncSession = Depends(get_database_session)):
-    result = await db.execute(select(Task).where(Task.assigned_user_id == user_id))
+    result = await db.execute(
+        select(Task).where(
+            Task.assigned_user_id == user_id, Task.deleted_at.is_(None)
+        )
+    )
     tasks = result.scalars().all()
     return [TaskResponseSchema.model_validate(task) for task in tasks]
 
@@ -38,6 +46,7 @@ async def get_tasks_assigned_by_user(
         Task.assigned_by_user_id == user_id,
         Task.assigned_user_id.isnot(None),
         Task.assigned_user_id != user_id,
+        Task.deleted_at.is_(None),
     )
     result = await db.execute(stmt)
     tasks = result.scalars().all()
@@ -47,7 +56,12 @@ async def get_tasks_assigned_by_user(
 @router.get("/tasks/reports/group/{group_id}", response_model=List[TaskResponseSchema])
 async def get_group_task_report(group_id: int, db: AsyncSession = Depends(get_database_session)):
     result = await db.execute(
-        select(Task).join(task_group_association).where(task_group_association.c.group_id == group_id)
+        select(Task)
+        .join(task_group_association)
+        .where(
+            task_group_association.c.group_id == group_id,
+            Task.deleted_at.is_(None),
+        )
     )
     tasks = result.scalars().all()
     return [TaskResponseSchema.model_validate(task) for task in tasks]
@@ -64,7 +78,10 @@ async def get_user_groups_tasks(
             user_group_membership,
             task_group_association.c.group_id == user_group_membership.c.group_id,
         )
-        .where(user_group_membership.c.user_id == user_id)
+        .where(
+            user_group_membership.c.user_id == user_id,
+            Task.deleted_at.is_(None),
+        )
     )
     result = await db.execute(stmt)
     tasks = result.scalars().unique().all()

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -32,12 +32,15 @@ UTC = ZoneInfo("UTC")
     summary="Get all tasks"
 )
 async def get_tasks(
+        include_archived: bool = False,
         db: AsyncSession = Depends(get_database_session)
 ) -> List[TaskResponseSchema]:
     """
     Retrieve all tasks from the system.
     """
     query = select(Task)
+    if not include_archived:
+        query = query.where(Task.deleted_at.is_(None))
     result = await db.execute(query)
     tasks = result.scalars().all()
     return [TaskResponseSchema.model_validate(task) for task in tasks]
@@ -74,12 +77,15 @@ async def create_task(
 )
 async def get_task_by_id(
         task_id: int,
+        include_archived: bool = False,
         db: AsyncSession = Depends(get_database_session)
 ) -> TaskResponseSchema:
     """
     Get detailed information about a specific task.
     """
     query = select(Task).where(Task.id == task_id)
+    if not include_archived:
+        query = query.where(Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -106,6 +112,7 @@ async def update_task(
     Update task information.
     """
     query = select(Task).where(Task.id == task_id)
+    query = query.where(Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -135,7 +142,7 @@ async def delete_task(
     """
     Delete a task from the system.
     """
-    query = select(Task).where(Task.id == task_id)
+    query = select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -145,7 +152,8 @@ async def delete_task(
             detail="Task not found"
         )
 
-    await db.delete(task)
+    task.deleted_at = datetime.now(UTC)
+    task.is_archived = True
     await db.commit()
 
 
@@ -161,7 +169,7 @@ async def assign_task_to_user(
         db: AsyncSession = Depends(get_database_session)
 ) -> TaskResponseSchema:
     """Assign a task to a specific user."""
-    query = select(Task).where(Task.id == task_id)
+    query = select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -191,7 +199,7 @@ async def unassign_task_from_user(
     """
     Remove the task assignment from a specific user.
     """
-    query = select(Task).where(Task.id == task_id)
+    query = select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -225,7 +233,7 @@ async def assign_task_to_groups(
         db: AsyncSession = Depends(get_database_session)
 ) -> TaskResponseSchema:
     """Assign a task to multiple groups."""
-    query = select(Task).where(Task.id == task_id)
+    query = select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -263,7 +271,7 @@ async def unassign_task_from_group(
         db: AsyncSession = Depends(get_database_session)
 ) -> TaskResponseSchema:
     """Remove the task assignment from a specific group."""
-    query = select(Task).where(Task.id == task_id)
+    query = select(Task).where(Task.id == task_id, Task.deleted_at.is_(None))
     result = await db.execute(query)
     task = result.scalar_one_or_none()
 
@@ -284,6 +292,37 @@ async def unassign_task_from_group(
         )
 
     task.assigned_groups.remove(group)
+    await db.commit()
+    await db.refresh(task)
+    return TaskResponseSchema.model_validate(task)
+
+
+@router.post(
+    "/{task_id}/restore",
+    response_model=TaskResponseSchema,
+    summary="Restore archived task",
+)
+async def restore_task(
+        task_id: int,
+        db: AsyncSession = Depends(get_database_session)
+) -> TaskResponseSchema:
+    """Restore a previously archived task."""
+    query = select(Task).where(Task.id == task_id)
+    result = await db.execute(query)
+    task = result.scalar_one_or_none()
+
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Task not found",
+        )
+    if task.deleted_at is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Task is not archived",
+        )
+    task.deleted_at = None
+    task.is_archived = False
     await db.commit()
     await db.refresh(task)
     return TaskResponseSchema.model_validate(task)

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -55,6 +55,11 @@ class TaskResponseSchema(TaskBaseSchema):
     created_at: datetime
     updated_at: datetime
     completed_at: Optional[datetime] = None
+    deleted_at: Optional[datetime] = None
+    is_archived: bool = Field(
+        default=False,
+        description="Indicates if the task is archived",
+    )
     assigned_user_id: Optional[int] = Field(
         None,
         gt=0,


### PR DESCRIPTION
## Summary
- add `deleted_at`/`is_archived` to tasks model and schema
- implement soft delete and restore endpoints
- filter reports and CRUD queries to exclude archived tasks

## Testing
- `poetry run pytest`
- `poetry run alembic upgrade head` *(fails: could not translate host name "postgres_db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6898666d0568832a8a867deb32cf2271