### PR TITLE
Track task creator separately from assignee

### DIFF
--- a/alembic/versions/0fc669666717_add_created_by_user_id_to_tasks.py
+++ b/alembic/versions/0fc669666717_add_created_by_user_id_to_tasks.py
@@ -1,0 +1,29 @@
+"""add created_by_user_id to tasks
+
+Revision ID: 0fc669666717
+Revises: 5c7f3042b1b1
+Create Date: 2025-07-03 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '0fc669666717'
+down_revision: Union[str, None] = '5c7f3042b1b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('tasks', sa.Column('created_by_user_id', sa.Integer(), nullable=False))
+    op.create_foreign_key(
+        'fk_tasks_created_by_user_id_users',
+        'tasks', 'users', ['created_by_user_id'], ['id']
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_tasks_created_by_user_id_users', 'tasks', type_='foreignkey')
+    op.drop_column('tasks', 'created_by_user_id')

--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -49,6 +49,10 @@ class TaskRepository:
         db_task = Task(
             title=task_data.title,
             description=task_data.description,
+            priority=task_data.priority,
+            assigned_user_id=task_data.assigned_user_id,
+            assigned_by_user_id=task_data.assigned_by_user_id,
+            created_by_user_id=task_data.created_by_user_id,
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC)
         )

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -46,6 +46,10 @@ class Task(Base):
         ForeignKey("users.id", ondelete="SET NULL"),
         nullable=True,
     )
+    created_by_user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"),
+        nullable=False,
+    )
 
     assigned_user = relationship(
         "User",
@@ -56,6 +60,11 @@ class Task(Base):
         "User",
         back_populates="assigned_tasks",
         foreign_keys=[assigned_by_user_id],
+    )
+    created_by = relationship(
+        "User",
+        back_populates="created_tasks",
+        foreign_keys=[created_by_user_id],
     )
     assigned_groups: Mapped[List[Group]] = relationship(
         Group,

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -68,6 +68,13 @@ class User(Base):
         foreign_keys="Task.assigned_by_user_id",
         lazy="selectin",
     )
+    # Tasks created by the user
+    created_tasks = relationship(
+        "Task",
+        back_populates="created_by",
+        foreign_keys="Task.created_by_user_id",
+        lazy="selectin",
+    )
 
     family = relationship(
         "Family",

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -57,9 +57,14 @@ async def create_task(
     Create a new task with the provided data.
     """
     new_task = Task(
-        **task_data.model_dump(),
+        title=task_data.title,
+        description=task_data.description,
+        priority=task_data.priority,
+        assigned_user_id=task_data.assigned_user_id,
+        assigned_by_user_id=task_data.assigned_by_user_id,
+        created_by_user_id=task_data.created_by_user_id,
         created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC)
+        updated_at=datetime.now(UTC),
     )
     db.add(new_task)
     await db.commit()

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -25,10 +25,19 @@ class TaskBaseSchema(BaseModel):
 class TaskCreateSchema(TaskBaseSchema):
     """Schema for creating a new task."""
     assigned_user_id: Optional[int] = Field(
-        ..., gt=0, description="ID of the user to assign; null for unassigned"
+        default=None,
+        gt=0,
+        description="ID of the user to assign; null for unassigned",
     )
-    assigned_by_user_id: int = Field(
-        ..., gt=0, description="ID of the user who assigns the task"
+    assigned_by_user_id: Optional[int] = Field(
+        default=None,
+        gt=0,
+        description="ID of the user who assigns the task",
+    )
+    created_by_user_id: int = Field(
+        ...,
+        gt=0,
+        description="ID of the user who created the task",
     )
 
 
@@ -40,6 +49,7 @@ class TaskUpdateSchema(BaseModel):
     is_completed: Optional[bool] = None
     assigned_user_id: Optional[int] = Field(None, gt=0)
     assigned_by_user_id: Optional[int] = Field(None, gt=0)
+    created_by_user_id: Optional[int] = Field(None, gt=0)
 
     class Config:
         from_attributes = True
@@ -64,6 +74,10 @@ class TaskResponseSchema(TaskBaseSchema):
         None,
         gt=0,
         description="ID of the user who assigned this task",
+    )
+    created_by_user_id: int = Field(
+        gt=0,
+        description="ID of the user who created this task",
     )
 
 class TaskAssignGroupsSchema(BaseModel):


### PR DESCRIPTION
## Summary
- add `created_by_user_id` column and relation for tasks
- expose creator ID in task schemas and responses
- handle creator ID in task creation and add migration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898666e86ec832aa3ed89466d8ac5c0