### PR TITLE
Add achievement model with task completion awards

### DIFF
--- a/alembic/versions/a1b2c3d4e5f6_add_achievements.py
+++ b/alembic/versions/a1b2c3d4e5f6_add_achievements.py
@@ -1,0 +1,43 @@
+"""add achievements
+
+Revision ID: a1b2c3d4e5f6
+Revises: 5c7f3042b1b1
+Create Date: 2025-07-01 00:00:01
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'a1b2c3d4e5f6'
+down_revision: Union[str, None] = '5c7f3042b1b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'achievements',
+        sa.Column('id', sa.Integer(), primary_key=True, index=True),
+        sa.Column('name', sa.String(length=100), nullable=False, unique=True),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()'), server_onupdate=sa.text('now()')),
+    )
+
+    op.create_table(
+        'user_achievements',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('achievement_id', sa.Integer(), nullable=False),
+        sa.Column('awarded_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['achievement_id'], ['achievements.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'achievement_id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('user_achievements')
+    op.drop_table('achievements')

--- a/app/crud/achievement.py
+++ b/app/crud/achievement.py
@@ -1,0 +1,111 @@
+from typing import List, Optional
+
+from sqlalchemy import select, insert, delete, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.achievement import Achievement, user_achievements
+from app.models.task import Task
+from app.schemas.achievement import (
+    AchievementCreateSchema,
+    AchievementUpdateSchema,
+    AchievementResponseSchema,
+)
+
+
+class AchievementRepository:
+    """Repository for managing achievements."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def create(self, data: AchievementCreateSchema) -> AchievementResponseSchema:
+        achievement = Achievement(**data.model_dump())
+        self.db.add(achievement)
+        await self.db.commit()
+        await self.db.refresh(achievement)
+        return AchievementResponseSchema.model_validate(achievement)
+
+    async def get(self, achievement_id: int) -> Optional[AchievementResponseSchema]:
+        result = await self.db.execute(
+            select(Achievement).where(Achievement.id == achievement_id)
+        )
+        achievement = result.scalars().first()
+        if achievement is None:
+            return None
+        return AchievementResponseSchema.model_validate(achievement)
+
+    async def get_all(self) -> List[AchievementResponseSchema]:
+        result = await self.db.execute(select(Achievement))
+        achievements = result.scalars().all()
+        return [AchievementResponseSchema.model_validate(a) for a in achievements]
+
+    async def update(
+        self, achievement_id: int, data: AchievementUpdateSchema
+    ) -> Optional[AchievementResponseSchema]:
+        result = await self.db.execute(
+            select(Achievement).where(Achievement.id == achievement_id)
+        )
+        achievement = result.scalars().first()
+        if achievement is None:
+            return None
+        for field, value in data.model_dump(exclude_unset=True).items():
+            setattr(achievement, field, value)
+        await self.db.commit()
+        await self.db.refresh(achievement)
+        return AchievementResponseSchema.model_validate(achievement)
+
+    async def delete(self, achievement_id: int) -> bool:
+        result = await self.db.execute(
+            select(Achievement).where(Achievement.id == achievement_id)
+        )
+        achievement = result.scalars().first()
+        if achievement is None:
+            return False
+        await self.db.delete(achievement)
+        await self.db.commit()
+        return True
+
+    async def award_to_user(self, achievement_id: int, user_id: int) -> None:
+        await self.db.execute(
+            insert(user_achievements)
+            .values(user_id=user_id, achievement_id=achievement_id)
+            .on_conflict_do_nothing()
+        )
+        await self.db.commit()
+
+    async def get_user_achievements(
+        self, user_id: int
+    ) -> List[AchievementResponseSchema]:
+        result = await self.db.execute(
+            select(Achievement)
+            .join(user_achievements, Achievement.id == user_achievements.c.achievement_id)
+            .where(user_achievements.c.user_id == user_id)
+        )
+        achievements = result.scalars().all()
+        return [AchievementResponseSchema.model_validate(a) for a in achievements]
+
+
+async def check_task_completion_achievements(db: AsyncSession, user_id: int) -> None:
+    """Award achievements for task completion milestones."""
+    result = await db.execute(
+        select(func.count(Task.id)).where(
+            Task.assigned_user_id == user_id, Task.is_completed.is_(True)
+        )
+    )
+    completed_count = result.scalar_one() or 0
+    if completed_count < 1:
+        return
+
+    achievement_result = await db.execute(
+        select(Achievement).where(Achievement.name == "First Task Completed")
+    )
+    achievement = achievement_result.scalar_one_or_none()
+    if not achievement:
+        return
+
+    await db.execute(
+        insert(user_achievements)
+        .values(user_id=user_id, achievement_id=achievement.id)
+        .on_conflict_do_nothing()
+    )
+    await db.commit()

--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.task import Task
 from app.models.group import Group
 from app.schemas.task import TaskCreateSchema, TaskResponseSchema, TaskUpdateSchema
+from app.crud.achievement import check_task_completion_achievements
 
 UTC = ZoneInfo("UTC")
 
@@ -116,6 +117,8 @@ class TaskRepository:
             task.completed_at = datetime.now(UTC)
 
         await self.db.commit()
+        if update_data.get('is_completed') and task.assigned_user_id:
+            await check_task_completion_achievements(self.db, task.assigned_user_id)
         await self.db.refresh(task)
         return self._to_task_details(task)
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,6 +2,7 @@ from .user import User
 from .group import Group
 from .family import Family
 from .task import Task
+from .achievement import Achievement, user_achievements
 from .associations import (
     task_group_association,
     user_group_membership,
@@ -15,9 +16,11 @@ __all__ = [
     "Group",
     "Family",
     "Task",
+    "Achievement",
     "task_group_association",
     "user_group_membership",
     "user_family_membership",
+    "user_achievements",
     "Setting",
     "Notification",
 ]

--- a/app/models/achievement.py
+++ b/app/models/achievement.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import List, Optional, TYPE_CHECKING
+
+from sqlalchemy import (
+    Table,
+    Column,
+    Integer,
+    String,
+    Text,
+    DateTime,
+    ForeignKey,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+user_achievements = Table(
+    "user_achievements",
+    Base.metadata,
+    Column("user_id", Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True),
+    Column("achievement_id", Integer, ForeignKey("achievements.id", ondelete="CASCADE"), primary_key=True),
+    Column(
+        "awarded_at",
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    ),
+)
+
+
+class Achievement(Base):
+    __tablename__ = "achievements"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    description: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    users: Mapped[List["User"]] = relationship(
+        "User",
+        secondary=user_achievements,
+        back_populates="achievements",
+        lazy="selectin",
+    )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -87,4 +87,11 @@ class User(Base):
         lazy="selectin",
     )
 
+    achievements = relationship(
+        "Achievement",
+        secondary="user_achievements",
+        back_populates="users",
+        lazy="selectin",
+    )
+
     creator = relationship("User", remote_side=[id])

--- a/app/schemas/achievement.py
+++ b/app/schemas/achievement.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class AchievementBaseSchema(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    description: Optional[str] = Field(default=None)
+
+    class Config:
+        from_attributes = True
+
+
+class AchievementCreateSchema(AchievementBaseSchema):
+    pass
+
+
+class AchievementUpdateSchema(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    description: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+class AchievementResponseSchema(AchievementBaseSchema):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True


### PR DESCRIPTION
## Summary
- add `Achievement` model and `user_achievements` link table
- expose user-achievement relationship and pydantic schemas
- award first-task completion achievement and provide CRUD utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689867077a40832a98a31174396b548f