### PR TITLE
feat: add membership models for groups and families

### DIFF
--- a/alembic/versions/c5c3a0a73a9b_add_membership_models.py
+++ b/alembic/versions/c5c3a0a73a9b_add_membership_models.py
@@ -1,0 +1,86 @@
+"""add membership models
+
+Revision ID: c5c3a0a73a9b
+Revises: 5c7f3042b1b1
+Create Date: 2025-07-22 00:00:00
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'c5c3a0a73a9b'
+down_revision: Union[str, None] = '5c7f3042b1b1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'group_memberships',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('group_id', sa.Integer(), nullable=False),
+        sa.Column('role', sa.String(length=50), nullable=False, server_default='member'),
+        sa.Column('joined_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['group_id'], ['groups.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'group_id')
+    )
+    op.create_table(
+        'family_memberships',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('family_id', sa.Integer(), nullable=False),
+        sa.Column('role', sa.String(length=50), nullable=False, server_default='member'),
+        sa.Column('joined_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['family_id'], ['families.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'family_id')
+    )
+    op.execute(
+        """
+        INSERT INTO group_memberships (user_id, group_id, role, joined_at)
+        SELECT user_id, group_id, 'member', now() FROM user_group_membership
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO family_memberships (user_id, family_id, role, joined_at)
+        SELECT user_id, family_id, 'member', now() FROM user_family_membership
+        """
+    )
+    op.drop_table('user_group_membership')
+    op.drop_table('user_family_membership')
+
+
+def downgrade() -> None:
+    op.create_table(
+        'user_group_membership',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('group_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['group_id'], ['groups.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'group_id')
+    )
+    op.create_table(
+        'user_family_membership',
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('family_id', sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['family_id'], ['families.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('user_id', 'family_id')
+    )
+    op.execute(
+        """
+        INSERT INTO user_group_membership (user_id, group_id)
+        SELECT user_id, group_id FROM group_memberships
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO user_family_membership (user_id, family_id)
+        SELECT user_id, family_id FROM family_memberships
+        """
+    )
+    op.drop_table('group_memberships')
+    op.drop_table('family_memberships')

--- a/app/crud/family.py
+++ b/app/crud/family.py
@@ -1,9 +1,9 @@
-from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.family import Family
 from app.models.group import Group
-from app.models.associations import user_group_membership, user_family_membership
+from app.models.membership import GroupMembership, FamilyMembership
 from app.schemas.family import FamilyCreate
 
 
@@ -24,16 +24,15 @@ async def create_family(db: AsyncSession, family: FamilyCreate) -> Family:
     await db.commit()
     await db.refresh(default_group)
 
-    # add creator to default group
-    await db.execute(
-        user_group_membership.insert().values(
-            user_id=family.created_by, group_id=default_group.id
+    # add creator to default group and family with owner role
+    db.add(
+        GroupMembership(
+            user_id=family.created_by, group_id=default_group.id, role="owner"
         )
     )
-    # add creator to family membership
-    await db.execute(
-        user_family_membership.insert().values(
-            user_id=family.created_by, family_id=db_family.id
+    db.add(
+        FamilyMembership(
+            user_id=family.created_by, family_id=db_family.id, role="owner"
         )
     )
     await db.commit()

--- a/app/crud/group.py
+++ b/app/crud/group.py
@@ -5,7 +5,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.group import Group
-from app.models.associations import user_group_membership
+from app.models.membership import GroupMembership
 from app.schemas.group import GroupCreate, GroupUpdate
 
 
@@ -93,8 +93,8 @@ async def get_groups_by_user(
     """Get all groups that a user belongs to."""
     query = (
         select(Group)
-        .join(user_group_membership, Group.id == user_group_membership.c.group_id)
-        .where(user_group_membership.c.user_id == user_id)
+        .join(GroupMembership, Group.id == GroupMembership.group_id)
+        .where(GroupMembership.user_id == user_id)
     )
     if active_only:
         query = query.where(Group.is_active.is_(True))
@@ -107,17 +107,21 @@ async def get_groups_by_user(
 async def add_users_to_group(
     db: AsyncSession,
     group_id: int,
-    user_ids: List[int]
+    user_roles: dict[int, str]
 ) -> Optional[Group]:
-    """Add users to a group."""
+    """Add users to a group with specific roles."""
     db_group = await get_group(db, group_id, active_only=False)
     if not db_group:
         return None
 
-    for uid in user_ids:
+    for uid, role in user_roles.items():
         await db.execute(
-            insert(user_group_membership).values(user_id=uid, group_id=group_id)
-            .on_conflict_do_nothing()
+            insert(GroupMembership)
+            .values(user_id=uid, group_id=group_id, role=role)
+            .on_conflict_do_update(
+                index_elements=[GroupMembership.user_id, GroupMembership.group_id],
+                set_={"role": role},
+            )
         )
 
     await db.commit()
@@ -136,9 +140,9 @@ async def remove_users_from_group(
         return None
 
     await db.execute(
-        delete(user_group_membership).where(
-            user_group_membership.c.group_id == group_id,
-            user_group_membership.c.user_id.in_(user_ids),
+        delete(GroupMembership).where(
+            GroupMembership.group_id == group_id,
+            GroupMembership.user_id.in_(user_ids),
         )
     )
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -2,11 +2,8 @@ from .user import User
 from .group import Group
 from .family import Family
 from .task import Task
-from .associations import (
-    task_group_association,
-    user_group_membership,
-    user_family_membership,
-)
+from .associations import task_group_association
+from .membership import GroupMembership, FamilyMembership
 from .setting import Setting
 from .notification import Notification
 
@@ -16,8 +13,8 @@ __all__ = [
     "Family",
     "Task",
     "task_group_association",
-    "user_group_membership",
-    "user_family_membership",
+    "GroupMembership",
+    "FamilyMembership",
     "Setting",
     "Notification",
 ]

--- a/app/models/associations.py
+++ b/app/models/associations.py
@@ -10,19 +10,3 @@ task_group_association = Table(
     Column('task_id', Integer, ForeignKey('tasks.id', ondelete="CASCADE"), primary_key=True),
     Column('group_id', Integer, ForeignKey('groups.id', ondelete="CASCADE"), primary_key=True),
 )
-
-# Association table between users and groups
-user_group_membership = Table(
-    'user_group_membership',
-    Base.metadata,
-    Column('user_id', Integer, ForeignKey('users.id', ondelete="CASCADE"), primary_key=True),
-    Column('group_id', Integer, ForeignKey('groups.id', ondelete="CASCADE"), primary_key=True),
-)
-
-# Association table between users and families (premium feature)
-user_family_membership = Table(
-    'user_family_membership',
-    Base.metadata,
-    Column('user_id', Integer, ForeignKey('users.id', ondelete="CASCADE"), primary_key=True),
-    Column('family_id', Integer, ForeignKey('families.id', ondelete="CASCADE"), primary_key=True),
-)

--- a/app/models/family.py
+++ b/app/models/family.py
@@ -6,11 +6,11 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.sql import func
 
 from app.database import Base
-from .associations import user_family_membership
 
 if TYPE_CHECKING:
     from .user import User
     from .group import Group
+    from .membership import FamilyMembership as FamilyMembershipType
 
 
 class Family(Base):
@@ -33,11 +33,17 @@ class Family(Base):
         back_populates="family",
         foreign_keys="User.family_id",
     )
+    premium_memberships: Mapped[List["FamilyMembershipType"]] = relationship(
+        "FamilyMembership",
+        back_populates="family",
+        cascade="all, delete-orphan",
+    )
     premium_members: Mapped[List["User"]] = relationship(
         "User",
-        secondary=user_family_membership,
+        secondary="family_memberships",
         back_populates="families",
         lazy="selectin",
+        viewonly=True,
     )
     groups: Mapped[List["Group"]] = relationship(
         "Group", back_populates="family", cascade="all, delete-orphan"

--- a/app/models/group.py
+++ b/app/models/group.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import List, Optional
 from sqlalchemy import Integer, String, Text, Boolean, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
-from .associations import task_group_association, user_group_membership
+from .associations import task_group_association
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from app.models.task import Task
     from app.models.user import User
+    from app.models.membership import GroupMembership as GroupMembershipType
 
 
 class Group(Base):
@@ -74,11 +75,17 @@ class Group(Base):
     )
 
     family = relationship("Family", back_populates="groups")
+    memberships: Mapped[List["GroupMembershipType"]] = relationship(
+        "GroupMembership",
+        back_populates="group",
+        cascade="all, delete-orphan",
+    )
     users: Mapped[List["User"]] = relationship(
         "User",
-        secondary=user_group_membership,
+        secondary="group_memberships",
         back_populates="groups",
         lazy="selectin",
+        viewonly=True,
     )
 
     # Relationship with Task via association table

--- a/app/models/membership.py
+++ b/app/models/membership.py
@@ -1,0 +1,29 @@
+from sqlalchemy import Column, Integer, ForeignKey, String, DateTime, text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class GroupMembership(Base):
+    __tablename__ = "group_memberships"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    group_id = Column(Integer, ForeignKey("groups.id", ondelete="CASCADE"), primary_key=True)
+    role = Column(String(50), nullable=False, server_default=text("'member'"))
+    joined_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user = relationship("User", back_populates="group_memberships")
+    group = relationship("Group", back_populates="memberships")
+
+
+class FamilyMembership(Base):
+    __tablename__ = "family_memberships"
+
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
+    family_id = Column(Integer, ForeignKey("families.id", ondelete="CASCADE"), primary_key=True)
+    role = Column(String(50), nullable=False, server_default=text("'member'"))
+    joined_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    user = relationship("User", back_populates="family_memberships")
+    family = relationship("Family", back_populates="premium_memberships")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -14,7 +14,13 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from app.database import Base
-from .associations import user_family_membership
+from typing import TYPE_CHECKING
+
+from .membership import GroupMembership, FamilyMembership
+
+if TYPE_CHECKING:
+    from app.models.group import Group
+    from app.models.family import Family
 
 
 class User(Base):
@@ -74,17 +80,31 @@ class User(Base):
         back_populates="members",
         foreign_keys="User.family_id",
     )
+    family_memberships = relationship(
+        "FamilyMembership",
+        back_populates="user",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
     families = relationship(
         "Family",
-        secondary=user_family_membership,
+        secondary="family_memberships",
         back_populates="premium_members",
+        lazy="selectin",
+        viewonly=True,
+    )
+    group_memberships = relationship(
+        "GroupMembership",
+        back_populates="user",
+        cascade="all, delete-orphan",
         lazy="selectin",
     )
     groups = relationship(
         "Group",
-        secondary="user_group_membership",
+        secondary="group_memberships",
         back_populates="users",
         lazy="selectin",
+        viewonly=True,
     )
 
     creator = relationship("User", remote_side=[id])

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -6,7 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.models.task import Task
-from app.models.associations import task_group_association, user_group_membership
+from app.models.associations import task_group_association
+from app.models.membership import GroupMembership
 from app.schemas.task import TaskResponseSchema
 
 router = APIRouter()
@@ -61,10 +62,10 @@ async def get_user_groups_tasks(
         select(Task)
         .join(task_group_association)
         .join(
-            user_group_membership,
-            task_group_association.c.group_id == user_group_membership.c.group_id,
+            GroupMembership,
+            task_group_association.c.group_id == GroupMembership.group_id,
         )
-        .where(user_group_membership.c.user_id == user_id)
+        .where(GroupMembership.user_id == user_id)
     )
     result = await db.execute(stmt)
     tasks = result.scalars().unique().all()


### PR DESCRIPTION
## Summary
- replace join tables with `GroupMembership` and `FamilyMembership` models
- track member roles and join timestamps
- migrate data to new membership tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986708ac5c832aa60be22b6b782759