### PR TITLE
feat: add global error handler

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -1,0 +1,13 @@
+from fastapi import Request, status
+from fastapi.responses import JSONResponse
+
+from app.core.exceptions import AppError, NotFoundError
+
+
+async def exception_handler(request: Request, exc: AppError) -> JSONResponse:
+    """Handle application-level exceptions and return JSON responses."""
+    status_code = status.HTTP_400_BAD_REQUEST
+    if isinstance(exc, NotFoundError):
+        status_code = status.HTTP_404_NOT_FOUND
+    detail = str(exc) or exc.__class__.__name__
+    return JSONResponse(status_code=status_code, content={"detail": detail})

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -13,7 +13,6 @@ from app.schemas.user import UserAdminResponseSchema, UserUpdateSchema
 from app.core.security import get_current_admin
 from app.models.user import UserRole
 from app.crud.user import update_user as crud_update_user
-from app.core.exceptions import UserNotFoundError
 
 
 router = APIRouter(
@@ -72,8 +71,5 @@ async def make_user_admin(
     db: AsyncSession = Depends(get_database_session),
 ) -> UserAdminResponseSchema:
     """Grant administrative rights to the specified user."""
-    try:
-        user = await crud_update_user(db, user_id, UserUpdateSchema(role=UserRole.ADMIN))
-    except UserNotFoundError:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    user = await crud_update_user(db, user_id, UserUpdateSchema(role=UserRole.ADMIN))
     return UserAdminResponseSchema.model_validate(user)

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,6 +1,5 @@
 from typing import List
-
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
@@ -19,7 +18,6 @@ from app.schemas.user import (
     UserUpdateSchema
 )
 from app.models.user import UserStatus
-from app.core.exceptions import UserNotFoundError
 
 router = APIRouter(
     prefix="/users",
@@ -77,13 +75,7 @@ async def get_user_details(
     Parameters:
     - **user_id**: unique identifier of the user
     """
-    try:
-        user = await crud_get_user(db, user_id)
-    except UserNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+    user = await crud_get_user(db, user_id)
     return UserResponseSchema.model_validate(user)
 
 
@@ -102,13 +94,7 @@ async def delete_user(
     Parameters:
     - **user_id**: unique identifier of the user to delete
     """
-    try:
-        await crud_delete_user(db, user_id)
-    except UserNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+    await crud_delete_user(db, user_id)
 
 
 @router.put(
@@ -128,13 +114,7 @@ async def update_user(
     - **user_id**: unique identifier of the user to update
     - **user_data**: updated user information
     """
-    try:
-        user = await crud_update_user(db, user_id, user_data)
-    except UserNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+    user = await crud_update_user(db, user_id, user_data)
     return UserResponseSchema.model_validate(user)
 
 
@@ -153,11 +133,5 @@ async def update_user_status_endpoint(
     db: AsyncSession = Depends(get_database_session),
 ) -> UserResponseSchema:
     """Update the status of a user."""
-    try:
-        user = await crud_update_user_status(db, user_id, status_data.status)
-    except UserNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="User not found",
-        )
+    user = await crud_update_user_status(db, user_id, status_data.status)
     return UserResponseSchema.model_validate(user)

--- a/app/startup.py
+++ b/app/startup.py
@@ -20,6 +20,8 @@ from app.models.user import User, UserRole
 from app.schemas.user import UserCreateSchema, UserUpdateSchema
 from pydantic import EmailStr
 from app.crud.user import create_user as crud_create_user, update_user as crud_update_user
+from app.core.error_handlers import exception_handler
+from app.core.exceptions import AppError
 
 # Logger setup
 logger = logging.getLogger(__name__)
@@ -103,6 +105,7 @@ class ApplicationSetup:
         """Initialize the application"""
         self.setup_cors()
         self.register_routers()
+        self.app.add_exception_handler(AppError, exception_handler)
         return self.app
 
 


### PR DESCRIPTION
## Summary
- add global handler for AppError returning JSON responses
- register handler during startup
- remove redundant try/except blocks in admin and user routes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898742c9aa4832abaa8ea15903a13f1