### PR TITLE
Refactor CRUD modules into repository classes and inject in routers

### DIFF
--- a/app/crud/group.py
+++ b/app/crud/group.py
@@ -9,143 +9,110 @@ from app.models.membership import GroupMembership
 from app.schemas.group import GroupCreate, GroupUpdate
 
 
-async def create_group(db: AsyncSession, group: GroupCreate) -> Group:
-    """Create a new group."""
-    db_group = Group(**group.model_dump())
-    db.add(db_group)
-    await db.commit()
-    await db.refresh(db_group)
-    return db_group
+class GroupRepository:
+    """Repository for managing groups."""
 
+    def __init__(self, db: AsyncSession):
+        self.db = db
 
-async def get_group(
-    db: AsyncSession,
-    group_id: int,
-    active_only: bool = True
-) -> Optional[Group]:
-    """Get a group by ID."""
-    query = select(Group).where(Group.id == group_id)
-    if active_only:
-        query = query.where(Group.is_active.is_(True))
-    result = await db.execute(query)
-    return result.scalar_one_or_none()
+    async def create(self, group: GroupCreate) -> Group:
+        db_group = Group(**group.model_dump())
+        self.db.add(db_group)
+        await self.db.commit()
+        await self.db.refresh(db_group)
+        return db_group
 
+    async def get(self, group_id: int, active_only: bool = True) -> Optional[Group]:
+        query = select(Group).where(Group.id == group_id)
+        if active_only:
+            query = query.where(Group.is_active.is_(True))
+        result = await self.db.execute(query)
+        return result.scalar_one_or_none()
 
-async def get_groups(
-    db: AsyncSession,
-    skip: int = 0,
-    limit: int = 100,
-    active_only: bool = True
-) -> List[Group]:
-    """Get a list of groups with pagination."""
-    query = select(Group)
-    if active_only:
-        query = query.where(Group.is_active.is_(True))
-    query = query.order_by(Group.id).offset(skip).limit(limit)
-    result = await db.execute(query)
-    groups = result.scalars().all()
-    return cast(List[Group], list(groups))
+    async def get_list(
+        self, skip: int = 0, limit: int = 100, active_only: bool = True
+    ) -> List[Group]:
+        query = select(Group)
+        if active_only:
+            query = query.where(Group.is_active.is_(True))
+        query = query.order_by(Group.id).offset(skip).limit(limit)
+        result = await self.db.execute(query)
+        groups = result.scalars().all()
+        return cast(List[Group], list(groups))
 
+    async def update(self, group_id: int, group_update: GroupUpdate) -> Optional[Group]:
+        db_group = await self.get(group_id, active_only=False)
+        if not db_group:
+            return None
+        update_data = group_update.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(db_group, field, value)
+        await self.db.commit()
+        await self.db.refresh(db_group)
+        return db_group
 
-async def update_group(
-    db: AsyncSession,
-    group_id: int,
-    group_update: GroupUpdate
-) -> Optional[Group]:
-    """Update a group by ID."""
-    db_group = await get_group(db, group_id, active_only=False)
-    if not db_group:
-        return None
+    async def delete(
+        self, group_id: int, hard_delete: bool = False
+    ) -> Optional[Group]:
+        db_group = await self.get(group_id, active_only=False)
+        if not db_group:
+            return None
+        if hard_delete:
+            await self.db.delete(db_group)
+        else:
+            db_group.is_active = False
+        await self.db.commit()
+        return db_group
 
-    update_data = group_update.model_dump(exclude_unset=True)
-    for field, value in update_data.items():
-        setattr(db_group, field, value)
+    async def get_by_user(
+        self, user_id: int, active_only: bool = True
+    ) -> List[Group]:
+        query = (
+            select(Group)
+            .join(GroupMembership, Group.id == GroupMembership.group_id)
+            .where(GroupMembership.user_id == user_id)
+        )
+        if active_only:
+            query = query.where(Group.is_active.is_(True))
+        query = query.order_by(Group.id)
+        result = await self.db.execute(query)
+        groups = result.scalars().all()
+        return cast(List[Group], list(groups))
 
-    await db.commit()
-    await db.refresh(db_group)
-    return db_group
+    async def add_users(
+        self, group_id: int, user_roles: dict[int, str]
+    ) -> Optional[Group]:
+        db_group = await self.get(group_id, active_only=False)
+        if not db_group:
+            return None
+        for uid, role in user_roles.items():
+            await self.db.execute(
+                insert(GroupMembership)
+                .values(user_id=uid, group_id=group_id, role=role)
+                .on_conflict_do_update(
+                    index_elements=[
+                        GroupMembership.user_id,
+                        GroupMembership.group_id,
+                    ],
+                    set_={"role": role},
+                )
+            )
+        await self.db.commit()
+        await self.db.refresh(db_group)
+        return db_group
 
-
-async def delete_group(
-    db: AsyncSession,
-    group_id: int,
-    hard_delete: bool = False
-) -> Optional[Group]:
-    """Delete a group by ID."""
-    db_group = await get_group(db, group_id, active_only=False)
-    if not db_group:
-        return None
-
-    if hard_delete:
-        await db.delete(db_group)
-    else:
-        db_group.is_active = False
-
-    await db.commit()
-    return db_group
-
-
-async def get_groups_by_user(
-    db: AsyncSession,
-    user_id: int,
-    active_only: bool = True
-) -> List[Group]:
-    """Get all groups that a user belongs to."""
-    query = (
-        select(Group)
-        .join(GroupMembership, Group.id == GroupMembership.group_id)
-        .where(GroupMembership.user_id == user_id)
-    )
-    if active_only:
-        query = query.where(Group.is_active.is_(True))
-    query = query.order_by(Group.id)
-    result = await db.execute(query)
-    groups = result.scalars().all()
-    return cast(List[Group], list(groups))
-
-
-async def add_users_to_group(
-    db: AsyncSession,
-    group_id: int,
-    user_roles: dict[int, str]
-) -> Optional[Group]:
-    """Add users to a group with specific roles."""
-    db_group = await get_group(db, group_id, active_only=False)
-    if not db_group:
-        return None
-
-    for uid, role in user_roles.items():
-        await db.execute(
-            insert(GroupMembership)
-            .values(user_id=uid, group_id=group_id, role=role)
-            .on_conflict_do_update(
-                index_elements=[GroupMembership.user_id, GroupMembership.group_id],
-                set_={"role": role},
+    async def remove_users(
+        self, group_id: int, user_ids: List[int]
+    ) -> Optional[Group]:
+        db_group = await self.get(group_id, active_only=False)
+        if not db_group:
+            return None
+        await self.db.execute(
+            delete(GroupMembership).where(
+                GroupMembership.group_id == group_id,
+                GroupMembership.user_id.in_(user_ids),
             )
         )
-
-    await db.commit()
-    await db.refresh(db_group)
-    return db_group
-
-
-async def remove_users_from_group(
-    db: AsyncSession,
-    group_id: int,
-    user_ids: List[int]
-) -> Optional[Group]:
-    """Remove users from a group."""
-    db_group = await get_group(db, group_id, active_only=False)
-    if not db_group:
-        return None
-
-    await db.execute(
-        delete(GroupMembership).where(
-            GroupMembership.group_id == group_id,
-            GroupMembership.user_id.in_(user_ids),
-        )
-    )
-
-    await db.commit()
-    await db.refresh(db_group)
-    return db_group
+        await self.db.commit()
+        await self.db.refresh(db_group)
+        return db_group

--- a/app/crud/notification.py
+++ b/app/crud/notification.py
@@ -1,4 +1,5 @@
 from typing import List, Optional
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -6,35 +7,44 @@ from app.models.notification import Notification
 from app.schemas.notification import NotificationCreate
 
 
-async def get_notifications(db: AsyncSession, user_id: int) -> List[Notification]:
-    result = await db.execute(select(Notification).where(Notification.user_id == user_id))
-    return list(result.scalars().all())
+class NotificationRepository:
+    """Repository for managing notifications."""
 
+    def __init__(self, db: AsyncSession):
+        self.db = db
 
-async def create_notification(db: AsyncSession, data: NotificationCreate) -> Notification:
-    notification = Notification(**data.model_dump())
-    db.add(notification)
-    await db.commit()
-    await db.refresh(notification)
-    return notification
+    async def get_by_user(self, user_id: int) -> List[Notification]:
+        result = await self.db.execute(
+            select(Notification).where(Notification.user_id == user_id)
+        )
+        return list(result.scalars().all())
 
+    async def create(self, data: NotificationCreate) -> Notification:
+        notification = Notification(**data.model_dump())
+        self.db.add(notification)
+        await self.db.commit()
+        await self.db.refresh(notification)
+        return notification
 
-async def mark_as_read(db: AsyncSession, notification_id: int) -> Optional[Notification]:
-    result = await db.execute(select(Notification).where(Notification.id == notification_id))
-    notification = result.scalar_one_or_none()
-    if notification is None:
-        return None
-    notification.is_read = True
-    await db.commit()
-    await db.refresh(notification)
-    return notification
+    async def mark_as_read(self, notification_id: int) -> Optional[Notification]:
+        result = await self.db.execute(
+            select(Notification).where(Notification.id == notification_id)
+        )
+        notification = result.scalar_one_or_none()
+        if notification is None:
+            return None
+        notification.is_read = True
+        await self.db.commit()
+        await self.db.refresh(notification)
+        return notification
 
-
-async def delete_notification(db: AsyncSession, notification_id: int) -> bool:
-    result = await db.execute(select(Notification).where(Notification.id == notification_id))
-    notification = result.scalar_one_or_none()
-    if notification is None:
-        return False
-    await db.delete(notification)
-    await db.commit()
-    return True
+    async def delete(self, notification_id: int) -> bool:
+        result = await self.db.execute(
+            select(Notification).where(Notification.id == notification_id)
+        )
+        notification = result.scalar_one_or_none()
+        if notification is None:
+            return False
+        await self.db.delete(notification)
+        await self.db.commit()
+        return True

--- a/app/crud/task.py
+++ b/app/crud/task.py
@@ -9,7 +9,7 @@ from app.models.task import Task, TaskStatus
 from app.models.group import Group
 from app.models.user import User
 from app.schemas.task import TaskCreateSchema, TaskResponseSchema, TaskUpdateSchema
-from app.crud.achievement import check_task_completion_achievements
+from app.crud.achievement import AchievementRepository
 from app.core.exceptions import TaskNotFoundError
 
 UTC = ZoneInfo("UTC")
@@ -130,7 +130,9 @@ class TaskRepository:
 
         await self.db.commit()
         if update_data.get('is_completed') and task.assigned_user_id:
-            await check_task_completion_achievements(self.db, task.assigned_user_id)
+            await AchievementRepository(self.db).check_task_completion_achievements(
+                task.assigned_user_id
+            )
         await self.db.refresh(task)
         return self._to_task_details(task)
 

--- a/app/crud/user.py
+++ b/app/crud/user.py
@@ -1,122 +1,86 @@
 from typing import List
-from pydantic import BaseModel
 from datetime import datetime, UTC
 from sqlalchemy import select, bindparam
 from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.models.user import User, UserStatus
 from app.schemas.user import UserCreateSchema, UserUpdateSchema
-from app.core.security import (
-    generate_reset_token,
-    hash_password,
-    verify_reset_token,
-)
+from app.core.security import hash_password
 from app.core.exceptions import UserNotFoundError
 
 
-class UserCreate(BaseModel):
-    """Schema for user creation."""
-    username: str
-    email: str
-    password: str
+class UserRepository:
+    """Repository for managing user operations."""
 
-    class Config:
-        from_attributes = True
+    def __init__(self, db: AsyncSession):
+        self.db = db
 
+    async def get_all(self) -> List[User]:
+        """Retrieve all users."""
+        result = await self.db.execute(select(User))
+        return list(result.scalars().all())
 
-async def get_users(db: AsyncSession) -> List[User]:
-    """Retrieve all users from the database."""
-    result = await db.execute(select(User))
-    return list(result.scalars().all())
+    async def create(self, user_data: UserCreateSchema) -> User:
+        """Create a new user."""
+        hashed_password = hash_password(user_data.password)
+        new_user = User(
+            username=user_data.username,
+            email=user_data.email,
+            hashed_password=hashed_password,
+            is_active=True,
+            status=UserStatus.ACTIVE,
+            is_superuser=user_data.is_superuser,
+            is_premium=user_data.is_premium,
+            first_name=user_data.first_name,
+            last_name=user_data.last_name,
+            avatar_url=user_data.avatar_url,
+            locale=user_data.locale,
+            timezone=user_data.timezone,
+            points=user_data.points,
+            level=user_data.level,
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            created_by=user_data.created_by,
+            family_id=user_data.family_id,
+        )
+        self.db.add(new_user)
+        await self.db.commit()
+        await self.db.refresh(new_user)
+        return new_user
 
+    async def get_by_id(self, user_id: int) -> User:
+        """Retrieve a user by id."""
+        stmt = select(User).where(User.id == bindparam("uid"))
+        result = await self.db.execute(stmt, {"uid": user_id})
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise UserNotFoundError
+        return user
 
+    async def update(self, user_id: int, user_update: UserUpdateSchema) -> User:
+        """Update an existing user."""
+        user = await self.get_by_id(user_id)
+        update_data = user_update.model_dump(exclude_unset=True)
+        if "password" in update_data:
+            update_data["hashed_password"] = hash_password(update_data.pop("password"))
+        for field, value in update_data.items():
+            setattr(user, field, value)
+        user.updated_at = datetime.now(UTC)
+        await self.db.commit()
+        await self.db.refresh(user)
+        return user
 
+    async def delete(self, user_id: int) -> None:
+        """Delete a user by id."""
+        user = await self.get_by_id(user_id)
+        await self.db.delete(user)
+        await self.db.commit()
 
-async def create_user(db: AsyncSession, user_data: UserCreateSchema) -> User:
-    """Create a new user."""
-    hashed_password = hash_password(user_data.password)
-    new_user = User(
-        username=user_data.username,
-        email=user_data.email,
-        hashed_password=hashed_password,
-        is_active=True,
-        status=UserStatus.ACTIVE,
-        is_superuser=user_data.is_superuser,
-        is_premium=user_data.is_premium,
-        first_name=user_data.first_name,
-        last_name=user_data.last_name,
-        avatar_url=user_data.avatar_url,
-        locale=user_data.locale,
-        timezone=user_data.timezone,
-        points=user_data.points,
-        level=user_data.level,
-        created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC),
-        created_by=user_data.created_by,
-        family_id=user_data.family_id,
-    )
-    db.add(new_user)
-    await db.commit()
-    await db.refresh(new_user)
-    return new_user
-
-
-async def get_user(db: AsyncSession, user_id: int) -> User:
-    """Retrieve a user by id."""
-    stmt = select(User).where(User.id == bindparam("uid"))
-    result = await db.execute(stmt, {"uid": user_id})
-    user = result.scalar_one_or_none()
-    if user is None:
-        raise UserNotFoundError
-    return user
-
-
-async def update_user(
-    db: AsyncSession,
-    user_id: int,
-    user_update: UserUpdateSchema,
-) -> User:
-    """Update an existing user."""
-    stmt = select(User).where(User.id == bindparam("uid"))
-    result = await db.execute(stmt, {"uid": user_id})
-    user = result.scalar_one_or_none()
-    if user is None:
-        raise UserNotFoundError
-
-    update_data = user_update.model_dump(exclude_unset=True)
-    if "password" in update_data:
-        update_data["hashed_password"] = hash_password(update_data.pop("password"))
-    for field, value in update_data.items():
-        setattr(user, field, value)
-
-    user.updated_at = datetime.now(UTC)
-
-    await db.commit()
-    await db.refresh(user)
-    return user
-
-
-async def delete_user(db: AsyncSession, user_id: int) -> None:
-    """Delete a user by id."""
-    stmt = select(User).where(User.id == bindparam("uid"))
-    result = await db.execute(stmt, {"uid": user_id})
-    user = result.scalar_one_or_none()
-    if user is None:
-        raise UserNotFoundError
-    await db.delete(user)
-    await db.commit()
-
-
-async def update_user_status(
-    db: AsyncSession, user_id: int, status: UserStatus
-) -> User:
-    """Update only the status of a user."""
-    stmt = select(User).where(User.id == bindparam("uid"))
-    result = await db.execute(stmt, {"uid": user_id})
-    user = result.scalar_one_or_none()
-    if user is None:
-        raise UserNotFoundError
-    user.status = status
-    user.updated_at = datetime.now(UTC)
-    await db.commit()
-    await db.refresh(user)
-    return user
+    async def update_status(self, user_id: int, status: UserStatus) -> User:
+        """Update only the status of a user."""
+        user = await self.get_by_id(user_id)
+        user.status = status
+        user.updated_at = datetime.now(UTC)
+        await self.db.commit()
+        await self.db.refresh(user)
+        return user

--- a/app/routers/families.py
+++ b/app/routers/families.py
@@ -1,39 +1,45 @@
 from typing import List
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.schemas.family import FamilyCreate, FamilyResponse
-from app.crud.family import (
-    create_family as crud_create_family,
-    get_family as crud_get_family,
-    get_families as crud_get_families,
-)
+from app.crud.family import FamilyRepository
 
 router = APIRouter(prefix="/families", tags=["families"])
+
+
+def get_family_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> FamilyRepository:
+    return FamilyRepository(db)
 
 
 @router.post("/", response_model=FamilyResponse, status_code=status.HTTP_201_CREATED)
 async def create_family(
     family_data: FamilyCreate,
-    db: AsyncSession = Depends(get_database_session),
+    repo: FamilyRepository = Depends(get_family_repository),
 ) -> FamilyResponse:
-    new_family = await crud_create_family(db, family_data)
+    new_family = await repo.create(family_data)
     return FamilyResponse.model_validate(new_family)
 
 
 @router.get("/", response_model=List[FamilyResponse])
-async def list_families(db: AsyncSession = Depends(get_database_session)) -> List[FamilyResponse]:
-    families = await crud_get_families(db)
+async def list_families(
+    repo: FamilyRepository = Depends(get_family_repository),
+) -> List[FamilyResponse]:
+    families = await repo.get_all()
     return [FamilyResponse.model_validate(f) for f in families]
 
 
 @router.get("/{family_id}", response_model=FamilyResponse)
 async def get_family(
     family_id: int,
-    db: AsyncSession = Depends(get_database_session),
+    repo: FamilyRepository = Depends(get_family_repository),
 ) -> FamilyResponse:
-    family = await crud_get_family(db, family_id)
+    family = await repo.get(family_id)
     if family is None:
         raise HTTPException(status_code=404, detail="Family not found")
     return FamilyResponse.model_validate(family)

--- a/app/routers/groups.py
+++ b/app/routers/groups.py
@@ -6,32 +6,26 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.database import get_database_session
 from app.models.group import Group
 from app.schemas.group import GroupCreate, GroupUpdate, GroupResponse
-from app.crud.group import (
-    create_group as crud_create_group,
-    get_group as crud_get_group,
-    get_groups as crud_get_groups,
-    update_group as crud_update_group,
-    delete_group as crud_delete_group,
-    add_users_to_group as crud_add_users_to_group,
-    remove_users_from_group as crud_remove_users_from_group,
-)
+from app.crud.group import GroupRepository
 
-router = APIRouter(
-    prefix="/groups",
-    tags=["groups"]
-)
+router = APIRouter(prefix="/groups", tags=["groups"])
+
+
+def get_group_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> GroupRepository:
+    return GroupRepository(db)
+
 
 async def get_group_or_404(
     group_id: int,
-    db: AsyncSession
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> Group:
-    """Get a group by id or raise 404 exception."""
-    group = await crud_get_group(db, group_id, active_only=False)
-
+    group = await repo.get(group_id, active_only=False)
     if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found"
+            detail=f"Group with id {group_id} not found",
         )
     return group
 
@@ -40,12 +34,12 @@ async def get_group_or_404(
     "/",
     response_model=List[GroupResponse],
     summary="Get all groups",
-    description="Retrieve all groups from the system."
+    description="Retrieve all groups from the system.",
 )
 async def get_groups(
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> List[GroupResponse]:
-    groups = await crud_get_groups(db)
+    groups = await repo.get_list()
     return [GroupResponse.model_validate(group) for group in groups]
 
 
@@ -54,13 +48,13 @@ async def get_groups(
     response_model=GroupResponse,
     status_code=status.HTTP_201_CREATED,
     summary="Create new group",
-    description="Create a new group with the provided data."
+    description="Create a new group with the provided data.",
 )
 async def create_group(
     group_data: GroupCreate,
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> GroupResponse:
-    new_group = await crud_create_group(db, group_data)
+    new_group = await repo.create(group_data)
     return GroupResponse.model_validate(new_group)
 
 
@@ -68,13 +62,13 @@ async def create_group(
     "/{group_id}",
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete group",
-    description="Delete a group from the system."
+    description="Delete a group from the system.",
 )
 async def delete_group(
     group_id: Annotated[int, Path(gt=0)],
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> None:
-    group = await crud_delete_group(db, group_id)
+    group = await repo.delete(group_id)
     if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -86,14 +80,14 @@ async def delete_group(
     "/{group_id}",
     response_model=GroupResponse,
     summary="Update group",
-    description="Update group information."
+    description="Update group information.",
 )
 async def update_group(
     group_id: Annotated[int, Path(gt=0)],
     group_data: GroupUpdate,
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> GroupResponse:
-    group = await crud_update_group(db, group_id, group_data)
+    group = await repo.update(group_id, group_data)
     if group is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -106,22 +100,16 @@ async def update_group(
     "/{group_id}/users/{user_id}",
     response_model=GroupResponse,
     summary="Add user to group",
-    description="Add a user to a specific group."
+    description="Add a user to a specific group.",
 )
 async def add_user_to_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> GroupResponse:
-    group = await crud_get_group(db, group_id, active_only=False)
-    if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found",
-        )
-
-    updated_group = await crud_add_users_to_group(db, group_id, [user_id])
-    assert updated_group is not None  # for type checkers
+    group = await get_group_or_404(group_id, repo)
+    updated_group = await repo.add_users(group_id, {user_id: "member"})
+    assert updated_group is not None
     return GroupResponse.model_validate(updated_group)
 
 
@@ -129,20 +117,14 @@ async def add_user_to_group(
     "/{group_id}/users/{user_id}",
     response_model=GroupResponse,
     summary="Remove user from group",
-    description="Remove a user from a specific group."
+    description="Remove a user from a specific group.",
 )
 async def remove_user_from_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    db: AsyncSession = Depends(get_database_session)
+    repo: GroupRepository = Depends(get_group_repository),
 ) -> GroupResponse:
-    group = await crud_get_group(db, group_id, active_only=False)
-    if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found",
-        )
-
-    updated_group = await crud_remove_users_from_group(db, group_id, [user_id])
+    group = await get_group_or_404(group_id, repo)
+    updated_group = await repo.remove_users(group_id, [user_id])
     assert updated_group is not None
     return GroupResponse.model_validate(updated_group)

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -4,20 +4,24 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.crud.notification import (
-    get_notifications as crud_get_notifications,
-    create_notification as crud_create_notification,
-    mark_as_read as crud_mark_as_read,
-    delete_notification as crud_delete_notification,
-)
+from app.crud.notification import NotificationRepository
 from app.schemas.notification import NotificationResponse, NotificationCreate
 
 router = APIRouter()
 
 
+def get_notification_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> NotificationRepository:
+    return NotificationRepository(db)
+
+
 @router.get("/users/{user_id}/notifications", response_model=List[NotificationResponse])
-async def get_notifications(user_id: int, db: AsyncSession = Depends(get_database_session)):
-    notifications = await crud_get_notifications(db, user_id)
+async def get_notifications(
+    user_id: int,
+    repo: NotificationRepository = Depends(get_notification_repository),
+):
+    notifications = await repo.get_by_user(user_id)
     return [NotificationResponse.model_validate(n) for n in notifications]
 
 
@@ -26,24 +30,39 @@ async def get_notifications(user_id: int, db: AsyncSession = Depends(get_databas
     response_model=NotificationResponse,
     status_code=status.HTTP_201_CREATED,
 )
-async def create_notification(user_id: int, data: NotificationCreate, db: AsyncSession = Depends(get_database_session)):
-    notification = await crud_create_notification(
-        db,
-        NotificationCreate(user_id=user_id, message=data.message),
+async def create_notification(
+    user_id: int,
+    data: NotificationCreate,
+    repo: NotificationRepository = Depends(get_notification_repository),
+):
+    notification = await repo.create(
+        NotificationCreate(user_id=user_id, message=data.message)
     )
     return NotificationResponse.model_validate(notification)
 
 
-@router.post("/users/notifications/read/{notification_id}", response_model=NotificationResponse)
-async def mark_notification_as_read(notification_id: int, db: AsyncSession = Depends(get_database_session)):
-    notification = await crud_mark_as_read(db, notification_id)
+@router.post(
+    "/users/notifications/read/{notification_id}",
+    response_model=NotificationResponse,
+)
+async def mark_notification_as_read(
+    notification_id: int,
+    repo: NotificationRepository = Depends(get_notification_repository),
+):
+    notification = await repo.mark_as_read(notification_id)
     if notification is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
     return NotificationResponse.model_validate(notification)
 
 
-@router.delete("/users/notifications/{notification_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_notification(notification_id: int, db: AsyncSession = Depends(get_database_session)):
-    success = await crud_delete_notification(db, notification_id)
+@router.delete(
+    "/users/notifications/{notification_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_notification(
+    notification_id: int,
+    repo: NotificationRepository = Depends(get_notification_repository),
+):
+    success = await repo.delete(notification_id)
     if not success:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -2,15 +2,24 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.crud.setting import get_or_create_settings, update_settings
+from app.crud.setting import SettingRepository
 from app.schemas.setting import SettingResponse, SettingUpdate
 
 router = APIRouter()
 
 
+def get_setting_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> SettingRepository:
+    return SettingRepository(db)
+
+
 @router.get("/settings/{user_id}", response_model=SettingResponse)
-async def get_settings(user_id: int, db: AsyncSession = Depends(get_database_session)):
-    setting = await get_or_create_settings(db, user_id)
+async def get_settings(
+    user_id: int,
+    repo: SettingRepository = Depends(get_setting_repository),
+):
+    setting = await repo.get_or_create(user_id)
     return SettingResponse.model_validate(setting)
 
 
@@ -18,7 +27,7 @@ async def get_settings(user_id: int, db: AsyncSession = Depends(get_database_ses
 async def update_settings_endpoint(
     user_id: int,
     data: SettingUpdate,
-    db: AsyncSession = Depends(get_database_session),
+    repo: SettingRepository = Depends(get_setting_repository),
 ):
-    setting = await update_settings(db, user_id, data)
+    setting = await repo.update(user_id, data)
     return SettingResponse.model_validate(setting)

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -18,7 +18,7 @@ from app.schemas.task import (
     TaskAssignGroupsSchema,
     TaskAssignUserSchema,
 )
-from app.crud.achievement import check_task_completion_achievements
+from app.crud.achievement import AchievementRepository
 
 router = APIRouter(
     prefix="/tasks",
@@ -147,7 +147,9 @@ async def update_task(
 
     await db.commit()
     if new_status == TaskStatus.COMPLETED and task.assigned_user_id:
-        await check_task_completion_achievements(db, task.assigned_user_id)
+        await AchievementRepository(db).check_task_completion_achievements(
+            task.assigned_user_id
+        )
     await db.refresh(task)
     return TaskResponseSchema.model_validate(task)
 

--- a/app/routers/users.py
+++ b/app/routers/users.py
@@ -1,120 +1,94 @@
 from typing import List
+
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from pydantic import BaseModel
 
-from app.crud.user import (
-    get_users as crud_get_users,
-    create_user as crud_create_user,
-    get_user as crud_get_user,
-    update_user as crud_update_user,
-    delete_user as crud_delete_user,
-    update_user_status as crud_update_user_status,
-)
+from app.crud.user import UserRepository
 from app.database import get_database_session
 from app.schemas.user import (
     UserResponseSchema,
     UserCreateSchema,
-    UserUpdateSchema
+    UserUpdateSchema,
 )
 from app.models.user import UserStatus
 
-router = APIRouter(
-    prefix="/users",
-    tags=["users"]
-)
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+def get_user_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> UserRepository:
+    return UserRepository(db)
 
 
 @router.post(
     "/",
     response_model=UserResponseSchema,
     status_code=status.HTTP_201_CREATED,
-    summary="Create new user"
+    summary="Create new user",
 )
 async def create_user(
-        user_data: UserCreateSchema,
-        db: AsyncSession = Depends(get_database_session)
+    user_data: UserCreateSchema,
+    repo: UserRepository = Depends(get_user_repository),
 ) -> UserResponseSchema:
-    """
-    Create a new user with the provided data:
-    - **username**: required
-    - **email**: required
-    - **password**: required
-    """
-    new_user = await crud_create_user(db, user_data)
+    """Create a new user."""
+    new_user = await repo.create(user_data)
     return UserResponseSchema.model_validate(new_user)
 
 
 @router.get(
     "/",
     response_model=List[UserResponseSchema],
-    summary="Get all users"
+    summary="Get all users",
 )
 async def get_users_list(
-        db: AsyncSession = Depends(get_database_session)
+    repo: UserRepository = Depends(get_user_repository),
 ) -> List[UserResponseSchema]:
-    """
-    Retrieve all users from the system.
-    """
-    users = await crud_get_users(db)
+    """Retrieve all users from the system."""
+    users = await repo.get_all()
     return [UserResponseSchema.model_validate(user) for user in users]
 
 
 @router.get(
     "/{user_id}",
     response_model=UserResponseSchema,
-    summary="Get user by ID"
+    summary="Get user by ID",
 )
 async def get_user_details(
-        user_id: int,
-        db: AsyncSession = Depends(get_database_session)
+    user_id: int,
+    repo: UserRepository = Depends(get_user_repository),
 ) -> UserResponseSchema:
-    """
-    Get detailed information about a specific user.
-
-    Parameters:
-    - **user_id**: unique identifier of the user
-    """
-    user = await crud_get_user(db, user_id)
+    """Get detailed information about a specific user."""
+    user = await repo.get_by_id(user_id)
     return UserResponseSchema.model_validate(user)
 
 
 @router.delete(
     "/{user_id}",
     status_code=status.HTTP_204_NO_CONTENT,
-    summary="Delete user"
+    summary="Delete user",
 )
 async def delete_user(
-        user_id: int,
-        db: AsyncSession = Depends(get_database_session)
+    user_id: int,
+    repo: UserRepository = Depends(get_user_repository),
 ) -> None:
-    """
-    Delete a user from the system.
-
-    Parameters:
-    - **user_id**: unique identifier of the user to delete
-    """
-    await crud_delete_user(db, user_id)
+    """Delete a user from the system."""
+    await repo.delete(user_id)
 
 
 @router.put(
     "/{user_id}",
     response_model=UserResponseSchema,
-    summary="Update user"
+    summary="Update user",
 )
 async def update_user(
-        user_id: int,
-        user_data: UserUpdateSchema,
-        db: AsyncSession = Depends(get_database_session)
+    user_id: int,
+    user_data: UserUpdateSchema,
+    repo: UserRepository = Depends(get_user_repository),
 ) -> UserResponseSchema:
-    """
-    Update user information.
-
-    Parameters:
-    - **user_id**: unique identifier of the user to update
-    - **user_data**: updated user information
-    """
-    user = await crud_update_user(db, user_id, user_data)
+    """Update user information."""
+    user = await repo.update(user_id, user_data)
     return UserResponseSchema.model_validate(user)
 
 
@@ -130,8 +104,8 @@ class UserStatusUpdate(BaseModel):
 async def update_user_status_endpoint(
     user_id: int,
     status_data: UserStatusUpdate,
-    db: AsyncSession = Depends(get_database_session),
+    repo: UserRepository = Depends(get_user_repository),
 ) -> UserResponseSchema:
     """Update the status of a user."""
-    user = await crud_update_user_status(db, user_id, status_data.status)
+    user = await repo.update_status(user_id, status_data.status)
     return UserResponseSchema.model_validate(user)


### PR DESCRIPTION
## Summary
- introduce repository classes for user, group, family, notification and setting modules
- move achievement checks into AchievementRepository and adjust tasks
- update routers to inject repositories via FastAPI Depends

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898783ffa34832a8170164abc7410ce