### PR TITLE
Refactor routers to use AppError subclasses

### DIFF
--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -34,3 +34,21 @@ class UserNotFoundError(NotFoundError):
 
     detail = "User not found"
 
+
+class GroupNotFoundError(NotFoundError):
+    """Raised when a group is not found in the database."""
+
+    detail = "Group not found"
+
+
+class NotificationNotFoundError(NotFoundError):
+    """Raised when a notification is not found."""
+
+    detail = "Notification not found"
+
+
+class FamilyNotFoundError(NotFoundError):
+    """Raised when a family is not found in the database."""
+
+    detail = "Family not found"
+

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,7 +2,7 @@
 
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends
 from sqlalchemy import select, bindparam
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,7 @@ from app.schemas.user import UserAdminResponseSchema, UserUpdateSchema
 from app.core.security import get_current_admin
 from app.models.user import UserRole
 from app.crud.user import UserRepository
+from app.core.exceptions import UserNotFoundError
 
 
 router = APIRouter(
@@ -67,7 +68,7 @@ async def admin_get_user(
     result = await db.execute(stmt, {"uid": user_id})
     user = result.scalar_one_or_none()
     if user is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+        raise UserNotFoundError()
     return UserAdminResponseSchema.model_validate(user)
 
 

--- a/app/routers/families.py
+++ b/app/routers/families.py
@@ -1,12 +1,12 @@
 from typing import List
-from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.schemas.family import FamilyCreate, FamilyResponse
 from app.crud.family import FamilyRepository
+from app.core.exceptions import FamilyNotFoundError
 
 router = APIRouter(prefix="/families", tags=["families"])
 
@@ -41,5 +41,5 @@ async def get_family(
 ) -> FamilyResponse:
     family = await repo.get(family_id)
     if family is None:
-        raise HTTPException(status_code=404, detail="Family not found")
+        raise FamilyNotFoundError()
     return FamilyResponse.model_validate(family)

--- a/app/routers/groups.py
+++ b/app/routers/groups.py
@@ -1,12 +1,13 @@
 from typing import List, Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status, Path
+from fastapi import APIRouter, Depends, status, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.models.group import Group
 from app.schemas.group import GroupCreate, GroupUpdate, GroupResponse
 from app.crud.group import GroupRepository
+from app.core.exceptions import GroupNotFoundError
 
 router = APIRouter(prefix="/groups", tags=["groups"])
 
@@ -23,10 +24,7 @@ async def get_group_or_404(
 ) -> Group:
     group = await repo.get(group_id, active_only=False)
     if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found",
-        )
+        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
     return group
 
 
@@ -70,10 +68,7 @@ async def delete_group(
 ) -> None:
     group = await repo.delete(group_id)
     if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found",
-        )
+        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
 
 
 @router.put(
@@ -89,10 +84,7 @@ async def update_group(
 ) -> GroupResponse:
     group = await repo.update(group_id, group_data)
     if group is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Group with id {group_id} not found",
-        )
+        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
     return GroupResponse.model_validate(group)
 
 

--- a/app/routers/notifications.py
+++ b/app/routers/notifications.py
@@ -1,11 +1,12 @@
 from typing import List
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.crud.notification import NotificationRepository
 from app.schemas.notification import NotificationResponse, NotificationCreate
+from app.core.exceptions import NotificationNotFoundError
 
 router = APIRouter()
 
@@ -51,7 +52,7 @@ async def mark_notification_as_read(
 ):
     notification = await repo.mark_as_read(notification_id)
     if notification is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+        raise NotificationNotFoundError()
     return NotificationResponse.model_validate(notification)
 
 
@@ -65,4 +66,4 @@ async def delete_notification(
 ):
     success = await repo.delete(notification_id)
     if not success:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification not found")
+        raise NotificationNotFoundError()


### PR DESCRIPTION
## Summary
- raise domain-specific `AppError` subclasses instead of `HTTPException` throughout routers
- add not-found errors for groups, notifications, and families
- allow errors to bubble up to shared exception handler

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987b872398832a864e6696b0adcf2f