### PR TITLE
Refactor routers to use repositories

### DIFF
--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -12,38 +12,44 @@ from app.schemas.auth import (
     PasswordResetRequest,
     Token,
 )
-from app.crud.user import (
-    create_reset_token,
-    create_user,
-    reset_password,
-    update_user,
-)
-from app.crud.family import create_family
+from app.crud.user import UserRepository
+from app.crud.family import FamilyRepository
 from app.models.user import User
 from app.core.security import create_access_token, verify_password
 from app.core.exceptions import AppError, UserNotFoundError
 router = APIRouter(prefix="/auth", tags=["auth"])
 
 
+def get_user_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> UserRepository:
+    return UserRepository(db)
+
+
+def get_family_repository(
+    db: AsyncSession = Depends(get_database_session),
+) -> FamilyRepository:
+    return FamilyRepository(db)
+
+
 @router.post("/register", response_model=UserResponseSchema, status_code=status.HTTP_201_CREATED)
 async def register_user(
     user_data: UserCreateSchema,
-    db: AsyncSession = Depends(get_database_session),
+    user_repo: UserRepository = Depends(get_user_repository),
+    family_repo: FamilyRepository = Depends(get_family_repository),
 ) -> UserResponseSchema:
-    new_user = await create_user(db, user_data)
-    family = await create_family(
-        db,
-        FamilyCreate(name=f"{new_user.username}'s family", created_by=new_user.id),
+    new_user = await user_repo.create(user_data)
+    family = await family_repo.create(
+        FamilyCreate(name=f"{new_user.username}'s family", created_by=new_user.id)
     )
-    await update_user(db, new_user.id, UserUpdateSchema(family_id=family.id))
-    await db.refresh(new_user)
-    return UserResponseSchema.model_validate(new_user)
+    user = await user_repo.update(new_user.id, UserUpdateSchema(family_id=family.id))
+    return UserResponseSchema.model_validate(user)
 
 
 @router.post("/login", response_model=Token)
 async def login(
     credentials: LoginSchema,
-    db: AsyncSession = Depends(get_database_session),
+    repo: UserRepository = Depends(get_user_repository),
 ) -> Token:
     if not credentials.username and not credentials.email:
         raise AppError("Username or email required")
@@ -57,12 +63,12 @@ async def login(
         query = query.where(User.email == bindparam("e"))
         params["e"] = credentials.email
 
-    result = await db.execute(query, params)
+    result = await repo.db.execute(query, params)
     user = result.scalar_one_or_none()
     if user is None or not verify_password(credentials.password, user.hashed_password):
         raise AppError("Invalid credentials")
 
-    await update_user(db, user.id, UserUpdateSchema(last_login_at=datetime.now(UTC)))
+    await repo.update(user.id, UserUpdateSchema(last_login_at=datetime.now(UTC)))
     token = create_access_token({"sub": str(user.id)})
     return Token(access_token=token)
 
@@ -70,9 +76,9 @@ async def login(
 @router.post("/request-password-reset")
 async def request_password_reset(
     data: PasswordResetRequest,
-    db: AsyncSession = Depends(get_database_session),
+    repo: UserRepository = Depends(get_user_repository),
 ):
-    token = await create_reset_token(db, data.email)
+    token = await repo.create_reset_token(data.email)
     if token is None:
         raise UserNotFoundError()
     return {"reset_token": token}
@@ -81,9 +87,9 @@ async def request_password_reset(
 @router.post("/reset-password")
 async def apply_password_reset(
     data: PasswordResetConfirm,
-    db: AsyncSession = Depends(get_database_session),
+    repo: UserRepository = Depends(get_user_repository),
 ):
-    success = await reset_password(db, data.token, data.new_password)
+    success = await repo.reset_password(data.token, data.new_password)
     if not success:
         raise AppError("Invalid or expired token")
     return {"message": "Password reset successful"}


### PR DESCRIPTION
## Summary
- inject `TaskRepository` into task routes and delegate CRUD & assignments to repository methods
- update auth flow and startup to use `UserRepository` and `FamilyRepository`
- extend repository layer with password reset and unassignment helpers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987ef09c24832a9530f95b96f4b63e