### PR TITLE
refactor: introduce service layer

### DIFF
--- a/app/routers/groups.py
+++ b/app/routers/groups.py
@@ -4,10 +4,9 @@ from fastapi import APIRouter, Depends, status, Path
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.models.group import Group
 from app.schemas.group import GroupCreate, GroupUpdate, GroupResponse
 from app.crud.group import GroupRepository
-from app.core.exceptions import GroupNotFoundError
+from app.services.group_service import GroupService
 
 router = APIRouter(prefix="/groups", tags=["groups"])
 
@@ -18,14 +17,10 @@ def get_group_repository(
     return GroupRepository(db)
 
 
-async def get_group_or_404(
-    group_id: int,
+def get_group_service(
     repo: GroupRepository = Depends(get_group_repository),
-) -> Group:
-    group = await repo.get(group_id, active_only=False)
-    if group is None:
-        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
-    return group
+) -> GroupService:
+    return GroupService(repo)
 
 
 @router.get(
@@ -35,10 +30,9 @@ async def get_group_or_404(
     description="Retrieve all groups from the system.",
 )
 async def get_groups(
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> List[GroupResponse]:
-    groups = await repo.get_list()
-    return [GroupResponse.model_validate(group) for group in groups]
+    return await service.get_groups()
 
 
 @router.post(
@@ -50,10 +44,9 @@ async def get_groups(
 )
 async def create_group(
     group_data: GroupCreate,
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> GroupResponse:
-    new_group = await repo.create(group_data)
-    return GroupResponse.model_validate(new_group)
+    return await service.create_group(group_data)
 
 
 @router.delete(
@@ -64,11 +57,9 @@ async def create_group(
 )
 async def delete_group(
     group_id: Annotated[int, Path(gt=0)],
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> None:
-    group = await repo.delete(group_id)
-    if group is None:
-        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
+    await service.delete_group(group_id)
 
 
 @router.put(
@@ -80,12 +71,9 @@ async def delete_group(
 async def update_group(
     group_id: Annotated[int, Path(gt=0)],
     group_data: GroupUpdate,
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> GroupResponse:
-    group = await repo.update(group_id, group_data)
-    if group is None:
-        raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
-    return GroupResponse.model_validate(group)
+    return await service.update_group(group_id, group_data)
 
 
 @router.post(
@@ -97,12 +85,9 @@ async def update_group(
 async def add_user_to_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> GroupResponse:
-    group = await get_group_or_404(group_id, repo)
-    updated_group = await repo.add_users(group_id, {user_id: "member"})
-    assert updated_group is not None
-    return GroupResponse.model_validate(updated_group)
+    return await service.add_user_to_group(group_id, user_id)
 
 
 @router.delete(
@@ -114,9 +99,6 @@ async def add_user_to_group(
 async def remove_user_from_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    repo: GroupRepository = Depends(get_group_repository),
+    service: GroupService = Depends(get_group_service),
 ) -> GroupResponse:
-    group = await get_group_or_404(group_id, repo)
-    updated_group = await repo.remove_users(group_id, [user_id])
-    assert updated_group is not None
-    return GroupResponse.model_validate(updated_group)
+    return await service.remove_user_from_group(group_id, user_id)

--- a/app/routers/reports.py
+++ b/app/routers/reports.py
@@ -1,86 +1,51 @@
+from fastapi import APIRouter, Depends
 from typing import List
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.models.task import Task
-from app.models.associations import task_group_association
-from app.models.membership import GroupMembership
 from app.schemas.task import TaskResponseSchema
+from app.services.report_service import ReportService
 
 router = APIRouter()
 
 
+def get_report_service(
+    db: AsyncSession = Depends(get_database_session),
+) -> ReportService:
+    return ReportService(db)
+
+
 @router.get("/tasks/reports/summary")
-async def get_task_summary(db: AsyncSession = Depends(get_database_session)):
-    total_result = await db.execute(
-        select(func.count()).select_from(Task).where(Task.deleted_at.is_(None))
-    )
-    total = total_result.scalar_one()
-    completed_result = await db.execute(
-        select(func.count())
-        .select_from(Task)
-        .where(Task.is_completed.is_(True), Task.deleted_at.is_(None))
-    )
-    completed = completed_result.scalar_one()
-    return {"total_tasks": total, "completed_tasks": completed}
+async def get_task_summary(
+    service: ReportService = Depends(get_report_service),
+):
+    return await service.get_task_summary()
 
 
 @router.get("/tasks/reports/user/{user_id}", response_model=List[TaskResponseSchema])
-async def get_user_task_report(user_id: int, db: AsyncSession = Depends(get_database_session)):
-    result = await db.execute(
-        select(Task).where(
-            Task.assigned_user_id == user_id, Task.deleted_at.is_(None)
-        )
-    )
-    tasks = result.scalars().all()
-    return [TaskResponseSchema.model_validate(task) for task in tasks]
+async def get_user_task_report(
+    user_id: int, service: ReportService = Depends(get_report_service)
+):
+    return await service.get_user_task_report(user_id)
 
 
 @router.get("/tasks/reports/assigned-by/{user_id}", response_model=List[TaskResponseSchema])
 async def get_tasks_assigned_by_user(
-    user_id: int, db: AsyncSession = Depends(get_database_session)
+    user_id: int, service: ReportService = Depends(get_report_service)
 ):
-    stmt = select(Task).where(
-        Task.assigned_by_user_id == user_id,
-        Task.assigned_user_id.isnot(None),
-        Task.assigned_user_id != user_id,
-        Task.deleted_at.is_(None),
-    )
-    result = await db.execute(stmt)
-    tasks = result.scalars().all()
-    return [TaskResponseSchema.model_validate(task) for task in tasks]
+    return await service.get_tasks_assigned_by_user(user_id)
 
 
 @router.get("/tasks/reports/group/{group_id}", response_model=List[TaskResponseSchema])
-async def get_group_task_report(group_id: int, db: AsyncSession = Depends(get_database_session)):
-    result = await db.execute(
-        select(Task)
-        .join(task_group_association)
-        .where(
-            task_group_association.c.group_id == group_id,
-            Task.deleted_at.is_(None),
-        )
-    )
-    tasks = result.scalars().all()
-    return [TaskResponseSchema.model_validate(task) for task in tasks]
+async def get_group_task_report(
+    group_id: int, service: ReportService = Depends(get_report_service)
+):
+    return await service.get_group_task_report(group_id)
 
 
 @router.get("/tasks/reports/user/{user_id}/groups", response_model=List[TaskResponseSchema])
 async def get_user_groups_tasks(
-    user_id: int, db: AsyncSession = Depends(get_database_session)
+    user_id: int, service: ReportService = Depends(get_report_service)
 ):
-    stmt = (
-        select(Task)
-        .join(task_group_association)
-        .join(
-            GroupMembership,
-            task_group_association.c.group_id == GroupMembership.group_id,
-        )
-        .where(GroupMembership.user_id == user_id)
-    )
-    result = await db.execute(stmt)
-    tasks = result.scalars().unique().all()
-    return [TaskResponseSchema.model_validate(task) for task in tasks]
+    return await service.get_user_groups_tasks(user_id)

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -12,6 +12,7 @@ from app.schemas.task import (
     TaskAssignGroupsSchema,
     TaskAssignUserSchema,
 )
+from app.services.task_service import TaskService
 
 router = APIRouter(prefix="/tasks", tags=["tasks"])
 
@@ -22,6 +23,12 @@ def get_task_repository(
     return TaskRepository(db)
 
 
+def get_task_service(
+    repo: TaskRepository = Depends(get_task_repository),
+) -> TaskService:
+    return TaskService(repo)
+
+
 @router.get(
     "/",
     response_model=List[TaskResponseSchema],
@@ -29,10 +36,10 @@ def get_task_repository(
 )
 async def get_tasks(
     include_archived: bool = False,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> List[TaskResponseSchema]:
     """Retrieve all tasks from the system."""
-    return await repo.get_all(include_archived)
+    return await service.get_tasks(include_archived)
 
 
 @router.post(
@@ -43,10 +50,10 @@ async def get_tasks(
 )
 async def create_task(
     task_data: TaskCreateSchema,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Create a new task with the provided data."""
-    return await repo.create(task_data)
+    return await service.create_task(task_data)
 
 
 @router.get(
@@ -57,10 +64,10 @@ async def create_task(
 async def get_task_by_id(
     task_id: int,
     include_archived: bool = False,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Get detailed information about a specific task."""
-    return await repo.get_by_id(task_id, include_archived)
+    return await service.get_task_by_id(task_id, include_archived)
 
 
 @router.put(
@@ -71,10 +78,10 @@ async def get_task_by_id(
 async def update_task(
     task_id: int,
     task_data: TaskUpdateSchema,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Update task information."""
-    return await repo.update(task_id, task_data)
+    return await service.update_task(task_id, task_data)
 
 
 @router.delete(
@@ -84,10 +91,10 @@ async def update_task(
 )
 async def delete_task(
     task_id: int,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> None:
     """Delete a task from the system."""
-    await repo.delete(task_id)
+    await service.delete_task(task_id)
 
 
 @router.post(
@@ -99,10 +106,10 @@ async def assign_task_to_user(
     task_id: int,
     user_id: int,
     assignment: TaskAssignUserSchema,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Assign a task to a specific user."""
-    return await repo.assign_to_user(task_id, user_id, assignment.assigned_by_user_id)
+    return await service.assign_task_to_user(task_id, user_id, assignment)
 
 
 @router.delete(
@@ -113,10 +120,10 @@ async def assign_task_to_user(
 async def unassign_task_from_user(
     task_id: int,
     user_id: int,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Remove the task assignment from a specific user."""
-    return await repo.unassign_from_user(task_id, user_id)
+    return await service.unassign_task_from_user(task_id, user_id)
 
 
 @router.post(
@@ -127,10 +134,10 @@ async def unassign_task_from_user(
 async def assign_task_to_groups(
     task_id: int,
     assignment: TaskAssignGroupsSchema,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Assign a task to multiple groups."""
-    return await repo.assign_to_groups(task_id, list(assignment.group_ids))
+    return await service.assign_task_to_groups(task_id, assignment)
 
 
 @router.delete(
@@ -141,10 +148,10 @@ async def assign_task_to_groups(
 async def unassign_task_from_group(
     task_id: int,
     group_id: int,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Remove the task assignment from a specific group."""
-    return await repo.unassign_from_group(task_id, group_id)
+    return await service.unassign_task_from_group(task_id, group_id)
 
 
 @router.post(
@@ -154,7 +161,7 @@ async def unassign_task_from_group(
 )
 async def restore_task(
     task_id: int,
-    repo: TaskRepository = Depends(get_task_repository),
+    service: TaskService = Depends(get_task_service),
 ) -> TaskResponseSchema:
     """Restore a previously archived task."""
-    return await repo.restore(task_id)
+    return await service.restore_task(task_id)

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,0 +1,70 @@
+from datetime import datetime, UTC
+from sqlalchemy import select, bindparam
+
+from app.crud.user import UserRepository
+from app.crud.family import FamilyRepository
+from app.schemas.user import UserCreateSchema, UserResponseSchema, UserUpdateSchema
+from app.schemas.family import FamilyCreate
+from app.schemas.auth import (
+    LoginSchema,
+    PasswordResetRequest,
+    PasswordResetConfirm,
+    Token,
+)
+from app.models.user import User
+from app.core.security import create_access_token, verify_password
+from app.core.exceptions import AppError, UserNotFoundError
+
+
+class AuthService:
+    """Service layer for authentication and authorization operations."""
+
+    def __init__(self, user_repo: UserRepository, family_repo: FamilyRepository):
+        self.user_repo = user_repo
+        self.family_repo = family_repo
+
+    async def register_user(self, user_data: UserCreateSchema) -> UserResponseSchema:
+        new_user = await self.user_repo.create(user_data)
+        family = await self.family_repo.create(
+            FamilyCreate(name=f"{new_user.username}'s family", created_by=new_user.id)
+        )
+        user = await self.user_repo.update(
+            new_user.id, UserUpdateSchema(family_id=family.id)
+        )
+        return UserResponseSchema.model_validate(user)
+
+    async def login(self, credentials: LoginSchema) -> Token:
+        if not credentials.username and not credentials.email:
+            raise AppError("Username or email required")
+
+        query = select(User)
+        params: dict[str, str] = {}
+        if credentials.username:
+            query = query.where(User.username == bindparam("u"))
+            params["u"] = credentials.username
+        else:
+            query = query.where(User.email == bindparam("e"))
+            params["e"] = credentials.email
+
+        result = await self.user_repo.db.execute(query, params)
+        user = result.scalar_one_or_none()
+        if user is None or not verify_password(credentials.password, user.hashed_password):
+            raise AppError("Invalid credentials")
+
+        await self.user_repo.update(
+            user.id, UserUpdateSchema(last_login_at=datetime.now(UTC))
+        )
+        token = create_access_token({"sub": str(user.id)})
+        return Token(access_token=token)
+
+    async def request_password_reset(self, data: PasswordResetRequest) -> dict:
+        token = await self.user_repo.create_reset_token(data.email)
+        if token is None:
+            raise UserNotFoundError()
+        return {"reset_token": token}
+
+    async def apply_password_reset(self, data: PasswordResetConfirm) -> dict:
+        success = await self.user_repo.reset_password(data.token, data.new_password)
+        if not success:
+            raise AppError("Invalid or expired token")
+        return {"message": "Password reset successful"}

--- a/app/services/group_service.py
+++ b/app/services/group_service.py
@@ -1,0 +1,47 @@
+from typing import List
+
+from app.crud.group import GroupRepository
+from app.schemas.group import GroupCreate, GroupUpdate, GroupResponse
+from app.core.exceptions import GroupNotFoundError
+
+
+class GroupService:
+    """Service layer for group-related operations."""
+
+    def __init__(self, repo: GroupRepository):
+        self.repo = repo
+
+    async def get_groups(self) -> List[GroupResponse]:
+        groups = await self.repo.get_list()
+        return [GroupResponse.model_validate(group) for group in groups]
+
+    async def create_group(self, group_data: GroupCreate) -> GroupResponse:
+        new_group = await self.repo.create(group_data)
+        return GroupResponse.model_validate(new_group)
+
+    async def delete_group(self, group_id: int) -> None:
+        group = await self.repo.delete(group_id)
+        if group is None:
+            raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
+
+    async def update_group(self, group_id: int, group_data: GroupUpdate) -> GroupResponse:
+        group = await self.repo.update(group_id, group_data)
+        if group is None:
+            raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
+        return GroupResponse.model_validate(group)
+
+    async def add_user_to_group(self, group_id: int, user_id: int) -> GroupResponse:
+        group = await self.repo.get(group_id, active_only=False)
+        if group is None:
+            raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
+        updated_group = await self.repo.add_users(group_id, {user_id: "member"})
+        assert updated_group is not None
+        return GroupResponse.model_validate(updated_group)
+
+    async def remove_user_from_group(self, group_id: int, user_id: int) -> GroupResponse:
+        group = await self.repo.get(group_id, active_only=False)
+        if group is None:
+            raise GroupNotFoundError(detail=f"Group with id {group_id} not found")
+        updated_group = await self.repo.remove_users(group_id, [user_id])
+        assert updated_group is not None
+        return GroupResponse.model_validate(updated_group)

--- a/app/services/report_service.py
+++ b/app/services/report_service.py
@@ -1,0 +1,73 @@
+from typing import List
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.task import Task
+from app.models.associations import task_group_association
+from app.models.membership import GroupMembership
+from app.schemas.task import TaskResponseSchema
+
+
+class ReportService:
+    """Service layer for generating reports."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_task_summary(self) -> dict:
+        total_result = await self.db.execute(
+            select(func.count()).select_from(Task).where(Task.deleted_at.is_(None))
+        )
+        total = total_result.scalar_one()
+        completed_result = await self.db.execute(
+            select(func.count())
+            .select_from(Task)
+            .where(Task.is_completed.is_(True), Task.deleted_at.is_(None))
+        )
+        completed = completed_result.scalar_one()
+        return {"total_tasks": total, "completed_tasks": completed}
+
+    async def get_user_task_report(self, user_id: int) -> List[TaskResponseSchema]:
+        result = await self.db.execute(
+            select(Task).where(Task.assigned_user_id == user_id, Task.deleted_at.is_(None))
+        )
+        tasks = result.scalars().all()
+        return [TaskResponseSchema.model_validate(task) for task in tasks]
+
+    async def get_tasks_assigned_by_user(self, user_id: int) -> List[TaskResponseSchema]:
+        stmt = select(Task).where(
+            Task.assigned_by_user_id == user_id,
+            Task.assigned_user_id.isnot(None),
+            Task.assigned_user_id != user_id,
+            Task.deleted_at.is_(None),
+        )
+        result = await self.db.execute(stmt)
+        tasks = result.scalars().all()
+        return [TaskResponseSchema.model_validate(task) for task in tasks]
+
+    async def get_group_task_report(self, group_id: int) -> List[TaskResponseSchema]:
+        result = await self.db.execute(
+            select(Task)
+            .join(task_group_association)
+            .where(
+                task_group_association.c.group_id == group_id,
+                Task.deleted_at.is_(None),
+            )
+        )
+        tasks = result.scalars().all()
+        return [TaskResponseSchema.model_validate(task) for task in tasks]
+
+    async def get_user_groups_tasks(self, user_id: int) -> List[TaskResponseSchema]:
+        stmt = (
+            select(Task)
+            .join(task_group_association)
+            .join(
+                GroupMembership,
+                task_group_association.c.group_id == GroupMembership.group_id,
+            )
+            .where(GroupMembership.user_id == user_id)
+        )
+        result = await self.db.execute(stmt)
+        tasks = result.scalars().unique().all()
+        return [TaskResponseSchema.model_validate(task) for task in tasks]

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -1,0 +1,61 @@
+from typing import List
+
+from app.crud.task import TaskRepository
+from app.schemas.task import (
+    TaskCreateSchema,
+    TaskResponseSchema,
+    TaskUpdateSchema,
+    TaskAssignGroupsSchema,
+    TaskAssignUserSchema,
+)
+
+
+class TaskService:
+    """Service layer for task-related operations."""
+
+    def __init__(self, repo: TaskRepository):
+        self.repo = repo
+
+    async def get_tasks(self, include_archived: bool = False) -> List[TaskResponseSchema]:
+        return await self.repo.get_all(include_archived)
+
+    async def create_task(self, task_data: TaskCreateSchema) -> TaskResponseSchema:
+        return await self.repo.create(task_data)
+
+    async def get_task_by_id(
+        self, task_id: int, include_archived: bool = False
+    ) -> TaskResponseSchema:
+        return await self.repo.get_by_id(task_id, include_archived)
+
+    async def update_task(
+        self, task_id: int, task_data: TaskUpdateSchema
+    ) -> TaskResponseSchema:
+        return await self.repo.update(task_id, task_data)
+
+    async def delete_task(self, task_id: int) -> None:
+        await self.repo.delete(task_id)
+
+    async def assign_task_to_user(
+        self, task_id: int, user_id: int, assignment: TaskAssignUserSchema
+    ) -> TaskResponseSchema:
+        return await self.repo.assign_to_user(
+            task_id, user_id, assignment.assigned_by_user_id
+        )
+
+    async def unassign_task_from_user(
+        self, task_id: int, user_id: int
+    ) -> TaskResponseSchema:
+        return await self.repo.unassign_from_user(task_id, user_id)
+
+    async def assign_task_to_groups(
+        self, task_id: int, assignment: TaskAssignGroupsSchema
+    ) -> TaskResponseSchema:
+        return await self.repo.assign_to_groups(task_id, list(assignment.group_ids))
+
+    async def unassign_task_from_group(
+        self, task_id: int, group_id: int
+    ) -> TaskResponseSchema:
+        return await self.repo.unassign_from_group(task_id, group_id)
+
+    async def restore_task(self, task_id: int) -> TaskResponseSchema:
+        return await self.repo.restore(task_id)


### PR DESCRIPTION
## Summary
- add service layer modules for auth, tasks, groups, and reports
- move business logic from routers to services returning schemas
- simplify routers to dependency wiring and service calls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68988193f9fc832a8ed71af7471cbfce