### PR TITLE
Add authentication and authorization error handling

### DIFF
--- a/app/core/error_handlers.py
+++ b/app/core/error_handlers.py
@@ -1,13 +1,22 @@
 from fastapi import Request, status
 from fastapi.responses import JSONResponse
 
-from app.core.exceptions import AppError, NotFoundError
+from app.core.exceptions import (
+    AppError,
+    AuthenticationError,
+    AuthorizationError,
+    NotFoundError,
+)
 
 
 async def exception_handler(request: Request, exc: AppError) -> JSONResponse:
     """Handle application-level exceptions and return JSON responses."""
     status_code = status.HTTP_400_BAD_REQUEST
-    if isinstance(exc, NotFoundError):
+    if isinstance(exc, AuthenticationError):
+        status_code = status.HTTP_401_UNAUTHORIZED
+    elif isinstance(exc, AuthorizationError):
+        status_code = status.HTTP_403_FORBIDDEN
+    elif isinstance(exc, NotFoundError):
         status_code = status.HTTP_404_NOT_FOUND
     detail = str(exc) or exc.__class__.__name__
     return JSONResponse(status_code=status_code, content={"detail": detail})

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -16,6 +16,20 @@ class AppError(Exception):
         super().__init__(self.detail)
 
 
+class AuthenticationError(AppError):
+    """Raised when authentication fails."""
+
+    status_code = 401
+    detail = "Authentication failed"
+
+
+class AuthorizationError(AppError):
+    """Raised when a user lacks necessary permissions."""
+
+    status_code = 403
+    detail = "Not authorized"
+
+
 class NotFoundError(AppError):
     """Raised when a requested entity does not exist."""
 

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict
 
 from jwt import PyJWTError, decode, encode
-from fastapi import Depends, HTTPException, status
+from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from passlib.context import CryptContext
 from sqlalchemy import select, bindparam
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
 from app.models.user import User, UserStatus, UserRole
+from app.core.exceptions import AuthenticationError, AuthorizationError
 
 SECRET_KEY = os.getenv("SECRET_KEY", "secret")
 ALGORITHM = "HS256"
@@ -61,12 +62,8 @@ def decode_access_token(token: str) -> Dict[str, Any]:
     """Decode a JWT token and return the payload."""
     try:
         return decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-    except PyJWTError as exc:  # noqa: B904 - re-raise with HTTP 401
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Could not validate credentials",
-            headers={"WWW-Authenticate": "Bearer"},
-        ) from exc
+    except PyJWTError as exc:  # noqa: B904 - re-raise with 401
+        raise AuthenticationError("Could not validate credentials") from exc
 
 
 async def get_current_user(
@@ -77,28 +74,26 @@ async def get_current_user(
     payload = decode_access_token(credentials.credentials)
     user_id = payload.get("sub")
     if user_id is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+        raise AuthenticationError("Invalid token payload")
 
     stmt = select(User).where(User.id == bindparam("uid"))
     result = await db.execute(stmt, {"uid": int(user_id)})
     user = result.scalar_one_or_none()
     if user is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+        raise AuthenticationError("User not found")
     return user
 
 
 async def get_current_active_user(user: User = Depends(get_current_user)) -> User:
     """Ensure the user is active."""
     if not user.is_active or user.status != UserStatus.ACTIVE:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Inactive user"
-        )
+        raise AuthenticationError("Inactive user")
     return user
 
 
 async def get_current_admin(user: User = Depends(get_current_active_user)) -> User:
     """Ensure the user has administrative privileges."""
     if user.role != UserRole.ADMIN:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+        raise AuthorizationError("Admin privileges required")
     return user
 


### PR DESCRIPTION
## Summary
- add AuthenticationError and AuthorizationError to custom exception hierarchy
- use these errors in security utilities instead of HTTPException
- extend application exception handler to return 401/403 statuses

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689883145040832a8b686fb9d6feced8