### PR TITLE
refactor: introduce service layer for user-related features

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -3,17 +3,13 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import select, bindparam
-from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.models.user import User
-from app.schemas.user import UserAdminResponseSchema, UserUpdateSchema
+from app.schemas.user import UserAdminResponseSchema
 from app.core.security import get_current_admin
-from app.models.user import UserRole
+from app.services import AdminService
 from app.crud.user import UserRepository
-from app.core.exceptions import UserNotFoundError
 
 
 router = APIRouter(
@@ -23,60 +19,34 @@ router = APIRouter(
 )
 
 
-def get_user_repository(
+def get_admin_service(
     db: AsyncSession = Depends(get_database_session),
-) -> UserRepository:
-    return UserRepository(db)
+) -> AdminService:
+    repo = UserRepository(db)
+    return AdminService(db, repo)
 
 
 @router.get("/users", response_model=List[UserAdminResponseSchema])
 async def admin_get_users(
-    db: AsyncSession = Depends(get_database_session),
+    service: AdminService = Depends(get_admin_service),
 ) -> List[UserAdminResponseSchema]:
     """Return all users with related data for admin inspection."""
-    result = await db.execute(
-        select(User)
-        .options(
-            selectinload(User.family),
-            selectinload(User.groups),
-            selectinload(User.tasks),
-            selectinload(User.notifications),
-            selectinload(User.settings),
-        )
-    )
-    users = result.scalars().all()
-    return [UserAdminResponseSchema.model_validate(u) for u in users]
+    return await service.get_users()
 
 
 @router.get("/users/{user_id}", response_model=UserAdminResponseSchema)
 async def admin_get_user(
     user_id: int,
-    db: AsyncSession = Depends(get_database_session),
+    service: AdminService = Depends(get_admin_service),
 ) -> UserAdminResponseSchema:
     """Return a single user with all related data."""
-    stmt = (
-        select(User)
-        .where(User.id == bindparam("uid"))
-        .options(
-            selectinload(User.family),
-            selectinload(User.groups),
-            selectinload(User.tasks),
-            selectinload(User.notifications),
-            selectinload(User.settings),
-        )
-    )
-    result = await db.execute(stmt, {"uid": user_id})
-    user = result.scalar_one_or_none()
-    if user is None:
-        raise UserNotFoundError()
-    return UserAdminResponseSchema.model_validate(user)
+    return await service.get_user(user_id)
 
 
 @router.post("/users/{user_id}/make-admin", response_model=UserAdminResponseSchema)
 async def make_user_admin(
     user_id: int,
-    repo: UserRepository = Depends(get_user_repository),
+    service: AdminService = Depends(get_admin_service),
 ) -> UserAdminResponseSchema:
     """Grant administrative rights to the specified user."""
-    user = await repo.update(user_id, UserUpdateSchema(role=UserRole.ADMIN))
-    return UserAdminResponseSchema.model_validate(user)
+    return await service.make_user_admin(user_id)

--- a/app/routers/settings.py
+++ b/app/routers/settings.py
@@ -2,32 +2,32 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_database_session
-from app.crud.setting import SettingRepository
 from app.schemas.setting import SettingResponse, SettingUpdate
+from app.services import SettingService
+from app.crud.setting import SettingRepository
 
 router = APIRouter()
 
 
-def get_setting_repository(
+def get_setting_service(
     db: AsyncSession = Depends(get_database_session),
-) -> SettingRepository:
-    return SettingRepository(db)
+) -> SettingService:
+    repo = SettingRepository(db)
+    return SettingService(repo)
 
 
 @router.get("/settings/{user_id}", response_model=SettingResponse)
 async def get_settings(
     user_id: int,
-    repo: SettingRepository = Depends(get_setting_repository),
+    service: SettingService = Depends(get_setting_service),
 ):
-    setting = await repo.get_or_create(user_id)
-    return SettingResponse.model_validate(setting)
+    return await service.get_settings(user_id)
 
 
 @router.put("/settings/{user_id}", response_model=SettingResponse)
 async def update_settings_endpoint(
     user_id: int,
     data: SettingUpdate,
-    repo: SettingRepository = Depends(get_setting_repository),
+    service: SettingService = Depends(get_setting_service),
 ):
-    setting = await repo.update(user_id, data)
-    return SettingResponse.model_validate(setting)
+    return await service.update_settings(user_id, data)

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,21 @@
+from .auth_service import AuthService
+from .group_service import GroupService
+from .report_service import ReportService
+from .task_service import TaskService
+from .user_service import UserService
+from .notification_service import NotificationService
+from .setting_service import SettingService
+from .family_service import FamilyService
+from .admin_service import AdminService
+
+__all__ = [
+    "AuthService",
+    "GroupService",
+    "ReportService",
+    "TaskService",
+    "UserService",
+    "NotificationService",
+    "SettingService",
+    "FamilyService",
+    "AdminService",
+]

--- a/app/services/admin_service.py
+++ b/app/services/admin_service.py
@@ -1,0 +1,49 @@
+from typing import List
+
+from sqlalchemy import select, bindparam
+from sqlalchemy.orm import selectinload
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User, UserRole
+from app.schemas.user import UserAdminResponseSchema, UserUpdateSchema
+from app.crud.user import UserRepository
+from app.core.exceptions import UserNotFoundError
+
+
+class AdminService:
+    """Service layer for admin-related user operations."""
+
+    def __init__(self, db: AsyncSession, repo: UserRepository):
+        self.db = db
+        self.repo = repo
+
+    async def get_users(self) -> List[UserAdminResponseSchema]:
+        result = await self.db.execute(
+            select(User).options(
+                selectinload(User.family),
+                selectinload(User.groups),
+                selectinload(User.tasks),
+                selectinload(User.notifications),
+                selectinload(User.settings),
+            )
+        )
+        users = result.scalars().all()
+        return [UserAdminResponseSchema.model_validate(u) for u in users]
+
+    async def get_user(self, user_id: int) -> UserAdminResponseSchema:
+        stmt = select(User).where(User.id == bindparam("uid")).options(
+            selectinload(User.family),
+            selectinload(User.groups),
+            selectinload(User.tasks),
+            selectinload(User.notifications),
+            selectinload(User.settings),
+        )
+        result = await self.db.execute(stmt, {"uid": user_id})
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise UserNotFoundError()
+        return UserAdminResponseSchema.model_validate(user)
+
+    async def make_user_admin(self, user_id: int) -> UserAdminResponseSchema:
+        user = await self.repo.update(user_id, UserUpdateSchema(role=UserRole.ADMIN))
+        return UserAdminResponseSchema.model_validate(user)

--- a/app/services/family_service.py
+++ b/app/services/family_service.py
@@ -1,0 +1,26 @@
+from typing import List
+
+from app.crud.family import FamilyRepository
+from app.schemas.family import FamilyCreate, FamilyResponse
+from app.core.exceptions import FamilyNotFoundError
+
+
+class FamilyService:
+    """Service layer for family-related operations."""
+
+    def __init__(self, repo: FamilyRepository):
+        self.repo = repo
+
+    async def create_family(self, data: FamilyCreate) -> FamilyResponse:
+        family = await self.repo.create(data)
+        return FamilyResponse.model_validate(family)
+
+    async def list_families(self) -> List[FamilyResponse]:
+        families = await self.repo.get_all()
+        return [FamilyResponse.model_validate(f) for f in families]
+
+    async def get_family(self, family_id: int) -> FamilyResponse:
+        family = await self.repo.get(family_id)
+        if family is None:
+            raise FamilyNotFoundError()
+        return FamilyResponse.model_validate(family)

--- a/app/services/notification_service.py
+++ b/app/services/notification_service.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from app.crud.notification import NotificationRepository
+from app.schemas.notification import NotificationResponse, NotificationCreate
+from app.core.exceptions import NotificationNotFoundError
+
+
+class NotificationService:
+    """Service layer for notification-related operations."""
+
+    def __init__(self, repo: NotificationRepository):
+        self.repo = repo
+
+    async def get_notifications(self, user_id: int) -> List[NotificationResponse]:
+        notifications = await self.repo.get_by_user(user_id)
+        return [NotificationResponse.model_validate(n) for n in notifications]
+
+    async def create_notification(
+        self, user_id: int, data: NotificationCreate
+    ) -> NotificationResponse:
+        notification = await self.repo.create(
+            NotificationCreate(user_id=user_id, message=data.message)
+        )
+        return NotificationResponse.model_validate(notification)
+
+    async def mark_as_read(self, notification_id: int) -> NotificationResponse:
+        notification = await self.repo.mark_as_read(notification_id)
+        if notification is None:
+            raise NotificationNotFoundError()
+        return NotificationResponse.model_validate(notification)
+
+    async def delete_notification(self, notification_id: int) -> None:
+        success = await self.repo.delete(notification_id)
+        if not success:
+            raise NotificationNotFoundError()

--- a/app/services/setting_service.py
+++ b/app/services/setting_service.py
@@ -1,0 +1,19 @@
+from app.crud.setting import SettingRepository
+from app.schemas.setting import SettingResponse, SettingUpdate
+
+
+class SettingService:
+    """Service layer for user settings operations."""
+
+    def __init__(self, repo: SettingRepository):
+        self.repo = repo
+
+    async def get_settings(self, user_id: int) -> SettingResponse:
+        setting = await self.repo.get_or_create(user_id)
+        return SettingResponse.model_validate(setting)
+
+    async def update_settings(
+        self, user_id: int, data: SettingUpdate
+    ) -> SettingResponse:
+        setting = await self.repo.update(user_id, data)
+        return SettingResponse.model_validate(setting)

--- a/app/services/user_service.py
+++ b/app/services/user_service.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from app.crud.user import UserRepository
+from app.schemas.user import (
+    UserCreateSchema,
+    UserResponseSchema,
+    UserUpdateSchema,
+)
+from app.models.user import UserStatus
+
+
+class UserService:
+    """Service layer for user-related operations."""
+
+    def __init__(self, repo: UserRepository):
+        self.repo = repo
+
+    async def create_user(self, user_data: UserCreateSchema) -> UserResponseSchema:
+        new_user = await self.repo.create(user_data)
+        return UserResponseSchema.model_validate(new_user)
+
+    async def get_users(self) -> List[UserResponseSchema]:
+        users = await self.repo.get_all()
+        return [UserResponseSchema.model_validate(user) for user in users]
+
+    async def get_user(self, user_id: int) -> UserResponseSchema:
+        user = await self.repo.get_by_id(user_id)
+        return UserResponseSchema.model_validate(user)
+
+    async def delete_user(self, user_id: int) -> None:
+        await self.repo.delete(user_id)
+
+    async def update_user(
+        self, user_id: int, user_data: UserUpdateSchema
+    ) -> UserResponseSchema:
+        user = await self.repo.update(user_id, user_data)
+        return UserResponseSchema.model_validate(user)
+
+    async def update_status(
+        self, user_id: int, status: UserStatus
+    ) -> UserResponseSchema:
+        user = await self.repo.update_status(user_id, status)
+        return UserResponseSchema.model_validate(user)


### PR DESCRIPTION
## Summary
- add dedicated services for users, notifications, settings, families and admin actions
- refactor routers to depend on service layer instead of direct repository access
- export all services through `app/services/__init__.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898879c1f88832aacaf0538917d6be3