### PR TITLE
Wire routers with dependency injector

### DIFF
--- a/app/domain/admin/router.py
+++ b/app/domain/admin/router.py
@@ -3,10 +3,11 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.users.schemas import UserAdminResponseSchema
 from app.core.security import get_current_admin
-from app.dependencies import container
+from app.dependencies import Container
 from app.domain.admin.service import AdminService
 
 
@@ -16,26 +17,29 @@ router = APIRouter(
     dependencies=[Depends(get_current_admin)],
 )
 @router.get("/users", response_model=List[UserAdminResponseSchema])
+@inject
 async def admin_get_users(
-    service: AdminService = Depends(container.admin_service),
+    service: AdminService = Depends(Provide[Container.admin_service]),
 ) -> List[UserAdminResponseSchema]:
     """Return all users with related data for admin inspection."""
     return await service.get_users()
 
 
 @router.get("/users/{user_id}", response_model=UserAdminResponseSchema)
+@inject
 async def admin_get_user(
     user_id: int,
-    service: AdminService = Depends(container.admin_service),
+    service: AdminService = Depends(Provide[Container.admin_service]),
 ) -> UserAdminResponseSchema:
     """Return a single user with all related data."""
     return await service.get_user(user_id)
 
 
 @router.post("/users/{user_id}/make-admin", response_model=UserAdminResponseSchema)
+@inject
 async def make_user_admin(
     user_id: int,
-    service: AdminService = Depends(container.admin_service),
+    service: AdminService = Depends(Provide[Container.admin_service]),
 ) -> UserAdminResponseSchema:
     """Grant administrative rights to the specified user."""
     return await service.make_user_admin(user_id)

--- a/app/domain/auth/router.py
+++ b/app/domain/auth/router.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, status
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.users.schemas import UserCreateSchema, UserResponseSchema
 from app.domain.auth.schemas import (
@@ -7,7 +8,7 @@ from app.domain.auth.schemas import (
     PasswordResetRequest,
     Token,
 )
-from app.dependencies import container
+from app.dependencies import Container
 from app.domain.auth.service import AuthService
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -18,32 +19,36 @@ router = APIRouter(prefix="/auth", tags=["auth"])
     response_model=UserResponseSchema,
     status_code=status.HTTP_201_CREATED,
 )
+@inject
 async def register_user(
     user_data: UserCreateSchema,
-    service: AuthService = Depends(container.auth_service),
+    service: AuthService = Depends(Provide[Container.auth_service]),
 ) -> UserResponseSchema:
     return await service.register_user(user_data)
 
 
 @router.post("/login", response_model=Token)
+@inject
 async def login(
     credentials: LoginSchema,
-    service: AuthService = Depends(container.auth_service),
+    service: AuthService = Depends(Provide[Container.auth_service]),
 ) -> Token:
     return await service.login(credentials)
 
 
 @router.post("/request-password-reset")
+@inject
 async def request_password_reset(
     data: PasswordResetRequest,
-    service: AuthService = Depends(container.auth_service),
+    service: AuthService = Depends(Provide[Container.auth_service]),
 ):
     return await service.request_password_reset(data)
 
 
 @router.post("/reset-password")
+@inject
 async def apply_password_reset(
     data: PasswordResetConfirm,
-    service: AuthService = Depends(container.auth_service),
+    service: AuthService = Depends(Provide[Container.auth_service]),
 ):
     return await service.apply_password_reset(data)

--- a/app/domain/families/router.py
+++ b/app/domain/families/router.py
@@ -1,32 +1,36 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, status
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.families.schemas import FamilyCreate, FamilyResponse
 from app.domain.families.service import FamilyService
-from app.dependencies import container
+from app.dependencies import Container
 
 router = APIRouter(prefix="/families", tags=["families"])
 
 
 @router.post("/", response_model=FamilyResponse, status_code=status.HTTP_201_CREATED)
+@inject
 async def create_family(
     family_data: FamilyCreate,
-    service: FamilyService = Depends(container.family_service),
+    service: FamilyService = Depends(Provide[Container.family_service]),
 ) -> FamilyResponse:
     return await service.create_family(family_data)
 
 
 @router.get("/", response_model=List[FamilyResponse])
+@inject
 async def list_families(
-    service: FamilyService = Depends(container.family_service),
+    service: FamilyService = Depends(Provide[Container.family_service]),
 ) -> List[FamilyResponse]:
     return await service.list_families()
 
 
 @router.get("/{family_id}", response_model=FamilyResponse)
+@inject
 async def get_family(
     family_id: int,
-    service: FamilyService = Depends(container.family_service),
+    service: FamilyService = Depends(Provide[Container.family_service]),
 ) -> FamilyResponse:
     return await service.get_family(family_id)

--- a/app/domain/groups/router.py
+++ b/app/domain/groups/router.py
@@ -1,8 +1,9 @@
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, Path, status
+from dependency_injector.wiring import inject, Provide
 
-from app.dependencies import container
+from app.dependencies import Container
 
 from .schemas import GroupCreate, GroupUpdate, GroupResponse
 from .service import GroupService
@@ -16,8 +17,9 @@ router = APIRouter(prefix="/groups", tags=["groups"])
     summary="Get all groups",
     description="Retrieve all groups from the system.",
 )
+@inject
 async def get_groups(
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> List[GroupResponse]:
     return await service.get_groups()
 
@@ -29,9 +31,10 @@ async def get_groups(
     summary="Create new group",
     description="Create a new group with the provided data.",
 )
+@inject
 async def create_group(
     group_data: GroupCreate,
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> GroupResponse:
     return await service.create_group(group_data)
 
@@ -42,9 +45,10 @@ async def create_group(
     summary="Delete group",
     description="Delete a group from the system.",
 )
+@inject
 async def delete_group(
     group_id: Annotated[int, Path(gt=0)],
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> None:
     await service.delete_group(group_id)
 
@@ -55,10 +59,11 @@ async def delete_group(
     summary="Update group",
     description="Update group information.",
 )
+@inject
 async def update_group(
     group_id: Annotated[int, Path(gt=0)],
     group_data: GroupUpdate,
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> GroupResponse:
     return await service.update_group(group_id, group_data)
 
@@ -69,10 +74,11 @@ async def update_group(
     summary="Add user to group",
     description="Add a user to a specific group.",
 )
+@inject
 async def add_user_to_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> GroupResponse:
     return await service.add_user_to_group(group_id, user_id)
 
@@ -83,9 +89,10 @@ async def add_user_to_group(
     summary="Remove user from group",
     description="Remove a user from a specific group.",
 )
+@inject
 async def remove_user_from_group(
     group_id: Annotated[int, Path(gt=0)],
     user_id: Annotated[int, Path(gt=0)],
-    service: GroupService = Depends(container.group_service),
+    service: GroupService = Depends(Provide[Container.group_service]),
 ) -> GroupResponse:
     return await service.remove_user_from_group(group_id, user_id)

--- a/app/domain/notifications/router.py
+++ b/app/domain/notifications/router.py
@@ -1,18 +1,20 @@
 from typing import List
 
 from fastapi import APIRouter, Depends, status
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.notifications.schemas import NotificationResponse, NotificationCreate
 from app.domain.notifications.service import NotificationService
-from app.dependencies import container
+from app.dependencies import Container
 
 router = APIRouter()
 
 
 @router.get("/users/{user_id}/notifications", response_model=List[NotificationResponse])
+@inject
 async def get_notifications(
     user_id: int,
-    service: NotificationService = Depends(container.notification_service),
+    service: NotificationService = Depends(Provide[Container.notification_service]),
 ):
     return await service.get_notifications(user_id)
 
@@ -22,10 +24,11 @@ async def get_notifications(
     response_model=NotificationResponse,
     status_code=status.HTTP_201_CREATED,
 )
+@inject
 async def create_notification(
     user_id: int,
     data: NotificationCreate,
-    service: NotificationService = Depends(container.notification_service),
+    service: NotificationService = Depends(Provide[Container.notification_service]),
 ):
     return await service.create_notification(user_id, data)
 
@@ -34,9 +37,10 @@ async def create_notification(
     "/users/notifications/read/{notification_id}",
     response_model=NotificationResponse,
 )
+@inject
 async def mark_notification_as_read(
     notification_id: int,
-    service: NotificationService = Depends(container.notification_service),
+    service: NotificationService = Depends(Provide[Container.notification_service]),
 ):
     return await service.mark_as_read(notification_id)
 
@@ -45,8 +49,9 @@ async def mark_notification_as_read(
     "/users/notifications/{notification_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
+@inject
 async def delete_notification(
     notification_id: int,
-    service: NotificationService = Depends(container.notification_service),
+    service: NotificationService = Depends(Provide[Container.notification_service]),
 ):
     await service.delete_notification(notification_id)

--- a/app/domain/reports/router.py
+++ b/app/domain/reports/router.py
@@ -1,44 +1,50 @@
 from typing import List
 
 from fastapi import APIRouter, Depends
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.tasks.schemas import TaskResponseSchema
 from app.domain.reports.service import ReportService
-from app.dependencies import container
+from app.dependencies import Container
 
 router = APIRouter()
 
 
 @router.get("/tasks/reports/summary")
+@inject
 async def get_task_summary(
-    service: ReportService = Depends(container.report_service),
+    service: ReportService = Depends(Provide[Container.report_service]),
 ):
     return await service.get_task_summary()
 
 
 @router.get("/tasks/reports/user/{user_id}", response_model=List[TaskResponseSchema])
+@inject
 async def get_user_task_report(
-    user_id: int, service: ReportService = Depends(container.report_service)
+    user_id: int, service: ReportService = Depends(Provide[Container.report_service])
 ):
     return await service.get_user_task_report(user_id)
 
 
 @router.get("/tasks/reports/assigned-by/{user_id}", response_model=List[TaskResponseSchema])
+@inject
 async def get_tasks_assigned_by_user(
-    user_id: int, service: ReportService = Depends(container.report_service)
+    user_id: int, service: ReportService = Depends(Provide[Container.report_service])
 ):
     return await service.get_tasks_assigned_by_user(user_id)
 
 
 @router.get("/tasks/reports/group/{group_id}", response_model=List[TaskResponseSchema])
+@inject
 async def get_group_task_report(
-    group_id: int, service: ReportService = Depends(container.report_service)
+    group_id: int, service: ReportService = Depends(Provide[Container.report_service])
 ):
     return await service.get_group_task_report(group_id)
 
 
 @router.get("/tasks/reports/user/{user_id}/groups", response_model=List[TaskResponseSchema])
+@inject
 async def get_user_groups_tasks(
-    user_id: int, service: ReportService = Depends(container.report_service)
+    user_id: int, service: ReportService = Depends(Provide[Container.report_service])
 ):
     return await service.get_user_groups_tasks(user_id)

--- a/app/domain/settings/router.py
+++ b/app/domain/settings/router.py
@@ -1,25 +1,27 @@
 from fastapi import APIRouter, Depends
-from fastapi import APIRouter, Depends
+from dependency_injector.wiring import inject, Provide
 
 from app.domain.settings.schemas import SettingResponse, SettingUpdate
 from app.domain.settings.service import SettingService
-from app.dependencies import container
+from app.dependencies import Container
 
 router = APIRouter()
 
 
 @router.get("/settings/{user_id}", response_model=SettingResponse)
+@inject
 async def get_settings(
     user_id: int,
-    service: SettingService = Depends(container.setting_service),
+    service: SettingService = Depends(Provide[Container.setting_service]),
 ):
     return await service.get_settings(user_id)
 
 
 @router.put("/settings/{user_id}", response_model=SettingResponse)
+@inject
 async def update_settings_endpoint(
     user_id: int,
     data: SettingUpdate,
-    service: SettingService = Depends(container.setting_service),
+    service: SettingService = Depends(Provide[Container.setting_service]),
 ):
     return await service.update_settings(user_id, data)

--- a/app/domain/tasks/router.py
+++ b/app/domain/tasks/router.py
@@ -1,7 +1,8 @@
 from typing import List
 from fastapi import APIRouter, Depends, status
+from dependency_injector.wiring import inject, Provide
 
-from app.dependencies import container
+from app.dependencies import Container
 from .schemas import (
     TaskCreateSchema,
     TaskResponseSchema,
@@ -19,9 +20,10 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
     response_model=List[TaskResponseSchema],
     summary="Get all tasks",
 )
+@inject
 async def get_tasks(
     include_archived: bool = False,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> List[TaskResponseSchema]:
     """Retrieve all tasks from the system."""
     return await service.get_tasks(include_archived)
@@ -33,9 +35,10 @@ async def get_tasks(
     status_code=status.HTTP_201_CREATED,
     summary="Create new task",
 )
+@inject
 async def create_task(
     task_data: TaskCreateSchema,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Create a new task with the provided data."""
     return await service.create_task(task_data)
@@ -46,10 +49,11 @@ async def create_task(
     response_model=TaskResponseSchema,
     summary="Get task by ID",
 )
+@inject
 async def get_task_by_id(
     task_id: int,
     include_archived: bool = False,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Get detailed information about a specific task."""
     return await service.get_task_by_id(task_id, include_archived)
@@ -60,10 +64,11 @@ async def get_task_by_id(
     response_model=TaskResponseSchema,
     summary="Update task",
 )
+@inject
 async def update_task(
     task_id: int,
     task_data: TaskUpdateSchema,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Update task information."""
     return await service.update_task(task_id, task_data)
@@ -74,9 +79,10 @@ async def update_task(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete task",
 )
+@inject
 async def delete_task(
     task_id: int,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> None:
     """Delete a task from the system."""
     await service.delete_task(task_id)
@@ -87,11 +93,12 @@ async def delete_task(
     response_model=TaskResponseSchema,
     summary="Assign task to user",
 )
+@inject
 async def assign_task_to_user(
     task_id: int,
     user_id: int,
     assignment: TaskAssignUserSchema,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Assign a task to a specific user."""
     return await service.assign_task_to_user(task_id, user_id, assignment)
@@ -102,10 +109,11 @@ async def assign_task_to_user(
     response_model=TaskResponseSchema,
     summary="Unassign task from user",
 )
+@inject
 async def unassign_task_from_user(
     task_id: int,
     user_id: int,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Remove the task assignment from a specific user."""
     return await service.unassign_task_from_user(task_id, user_id)
@@ -116,10 +124,11 @@ async def unassign_task_from_user(
     response_model=TaskResponseSchema,
     summary="Assign task to groups",
 )
+@inject
 async def assign_task_to_groups(
     task_id: int,
     assignment: TaskAssignGroupsSchema,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Assign a task to multiple groups."""
     return await service.assign_task_to_groups(task_id, assignment)
@@ -130,10 +139,11 @@ async def assign_task_to_groups(
     response_model=TaskResponseSchema,
     summary="Unassign task from group",
 )
+@inject
 async def unassign_task_from_group(
     task_id: int,
     group_id: int,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Remove the task assignment from a specific group."""
     return await service.unassign_task_from_group(task_id, group_id)
@@ -144,9 +154,10 @@ async def unassign_task_from_group(
     response_model=TaskResponseSchema,
     summary="Restore archived task",
 )
+@inject
 async def restore_task(
     task_id: int,
-    service: TaskService = Depends(container.task_service),
+    service: TaskService = Depends(Provide[Container.task_service]),
 ) -> TaskResponseSchema:
     """Restore a previously archived task."""
     return await service.restore_task(task_id)

--- a/app/domain/users/router.py
+++ b/app/domain/users/router.py
@@ -1,8 +1,9 @@
 from typing import List
 from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel
+from dependency_injector.wiring import inject, Provide
 
-from app.dependencies import container
+from app.dependencies import Container
 from .schemas import (
     UserResponseSchema,
     UserCreateSchema,
@@ -20,9 +21,10 @@ router = APIRouter(prefix="/users", tags=["users"])
     status_code=status.HTTP_201_CREATED,
     summary="Create new user",
 )
+@inject
 async def create_user(
     user_data: UserCreateSchema,
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> UserResponseSchema:
     """Create a new user."""
     return await service.create_user(user_data)
@@ -33,8 +35,9 @@ async def create_user(
     response_model=List[UserResponseSchema],
     summary="Get all users",
 )
+@inject
 async def get_users_list(
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> List[UserResponseSchema]:
     """Retrieve all users from the system."""
     return await service.get_users()
@@ -45,9 +48,10 @@ async def get_users_list(
     response_model=UserResponseSchema,
     summary="Get user by ID",
 )
+@inject
 async def get_user_details(
     user_id: int,
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> UserResponseSchema:
     """Get detailed information about a specific user."""
     return await service.get_user(user_id)
@@ -58,9 +62,10 @@ async def get_user_details(
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Delete user",
 )
+@inject
 async def delete_user(
     user_id: int,
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> None:
     """Delete a user from the system."""
     await service.delete_user(user_id)
@@ -71,10 +76,11 @@ async def delete_user(
     response_model=UserResponseSchema,
     summary="Update user",
 )
+@inject
 async def update_user(
     user_id: int,
     user_data: UserUpdateSchema,
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> UserResponseSchema:
     """Update user information."""
     return await service.update_user(user_id, user_data)
@@ -89,10 +95,11 @@ class UserStatusUpdate(BaseModel):
     response_model=UserResponseSchema,
     summary="Update user status",
 )
+@inject
 async def update_user_status_endpoint(
     user_id: int,
     status_data: UserStatusUpdate,
-    service: UserService = Depends(container.user_service),
+    service: UserService = Depends(Provide[Container.user_service]),
 ) -> UserResponseSchema:
     """Update the status of a user."""
     return await service.update_status(user_id, status_data.status)

--- a/app/startup.py
+++ b/app/startup.py
@@ -9,6 +9,15 @@ import importlib
 from app.core.logging import setup_logging
 from app.database import DatabaseConfig, DatabaseSessionManager, create_db_manager
 from app.dependencies import container
+from app.domain.users import router as users_router
+from app.domain.tasks import router as tasks_router
+from app.domain.settings import router as settings_router
+from app.domain.admin import router as admin_router
+from app.domain.families import router as families_router
+from app.domain.auth import router as auth_router
+from app.domain.notifications import router as notifications_router
+from app.domain.reports import router as reports_router
+from app.domain.groups import router as groups_router
 from app.domain.users.models import User, UserRole
 from app.domain.users.schemas import UserCreateSchema, UserUpdateSchema
 from pydantic import EmailStr
@@ -113,3 +122,17 @@ class ApplicationSetup:
 
 
 app = ApplicationSetup().initialize()
+
+container.wire(
+    modules=[
+        users_router,
+        tasks_router,
+        settings_router,
+        admin_router,
+        families_router,
+        auth_router,
+        notifications_router,
+        reports_router,
+        groups_router,
+    ]
+)


### PR DESCRIPTION
## Summary
- wire FastAPI routers to the DI container in startup
- use `@inject` and `Provide` in routers instead of container imports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898bb568954832a8afaad5a35ab19c7