### PR TITLE
Flush session after creating user and family

### DIFF
--- a/app/domain/auth/service.py
+++ b/app/domain/auth/service.py
@@ -41,9 +41,11 @@ class AuthService:
             user_repository = self.user_repository_factory(unit_of_work.session)
             family_repository = self.family_repository_factory(unit_of_work.session)
             new_user = await user_repository.create(user_data)
+            await unit_of_work.session.flush()
             family = await family_repository.create(
                 FamilyCreate(name=f"{new_user.username}'s family", created_by=new_user.id)
             )
+            await unit_of_work.session.flush()
             user = await user_repository.update(
                 new_user.id, UserUpdateSchema(family_id=family.id)
             )


### PR DESCRIPTION
## Summary
- Ensure new user ID is available by flushing the session after creating the user
- Flush again after creating the family before updating user with family ID

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d4b6f1c4832aad1f1e74410bdf0f