### PR TITLE
Flush session before returning newly created task

### DIFF
--- a/app/domain/tasks/repository.py
+++ b/app/domain/tasks/repository.py
@@ -57,6 +57,7 @@ class TaskRepository(BaseRepository[Task]):
         if db_task.status == TaskStatus.COMPLETED:
             db_task.completed_at = datetime.now(UTC)
         self.session.add(db_task)
+        await self.session.flush()
         return self._to_task_details(db_task)
 
     async def get_by_id(self, task_id: int, include_archived: bool = False) -> TaskResponseSchema:


### PR DESCRIPTION
## Summary
- flush SQLAlchemy session before converting a new task to schema

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898d5ae94a0832a99d912c973e1c53a