### PR TITLE
Refactor delete return value in notification repository

### DIFF
--- a/app/domain/notifications/repository.py
+++ b/app/domain/notifications/repository.py
@@ -33,4 +33,5 @@ class NotificationRepository(BaseRepository[Notification]):
         return notification
 
     async def delete(self, notification_id: int) -> bool:
-        return await super().delete(notification_id) is not None
+        deleted = await super().delete(notification_id)
+        return deleted is not None


### PR DESCRIPTION
## Summary
- clarify delete return logic in NotificationRepository by assigning the result before checking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d6b7e14c832a8af0b471977e0ceb