### PR TITLE
Trigger achievements when tasks are completed

### DIFF
--- a/app/domain/tasks/repository.py
+++ b/app/domain/tasks/repository.py
@@ -123,8 +123,6 @@ class TaskRepository(BaseRepository[Task]):
 
         update_data = task_data.model_dump(exclude_unset=True)
 
-        was_completed = task.is_completed
-
         for key, value in update_data.items():
             setattr(task, key, value)
 
@@ -136,10 +134,11 @@ class TaskRepository(BaseRepository[Task]):
             else:
                 task.completed_at = None
 
-        if update_data.get('is_completed') and task.assigned_user_id:
+        if status == TaskStatus.COMPLETED and task.assigned_user_id:
             await AchievementRepository(self.session).check_task_completion_achievements(
                 task.assigned_user_id
             )
+
         return self._to_task_details(task)
 
     async def delete(self, task_id: int) -> None:


### PR DESCRIPTION
## Summary
- remove unused `was_completed` flag in `TaskRepository.update`
- check task completion achievements based on `status == TaskStatus.COMPLETED`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d818982c832aa8e97487999287be